### PR TITLE
Adding babel plugin transform runtime. Resolves #17.

### DIFF
--- a/packages/generator-single-spa/src/react/templates/.babelrc
+++ b/packages/generator-single-spa/src/react/templates/.babelrc
@@ -4,6 +4,9 @@
     "@babel/preset-react"
   ],
   "plugins": [
-    "@babel/plugin-transform-runtime"
+    ["@babel/plugin-transform-runtime", {
+      "useESModules": true,
+      "regenerator": false
+    }]
   ]
 }

--- a/packages/generator-single-spa/src/react/templates/.babelrc
+++ b/packages/generator-single-spa/src/react/templates/.babelrc
@@ -4,5 +4,6 @@
     "@babel/preset-react"
   ],
   "plugins": [
+    "@babel/plugin-transform-runtime"
   ]
 }

--- a/packages/generator-single-spa/src/react/templates/package.json
+++ b/packages/generator-single-spa/src/react/templates/package.json
@@ -19,6 +19,7 @@
     "@babel/plugin-transform-runtime": "^7.8.3",
     "@babel/preset-env": "^7.7.6",
     "@babel/preset-react": "^7.7.4",
+    "@babel/runtime": "^7.0.0-beta.3",
     "@testing-library/react": "^9.4.0",
     "@types/jest": "^24.0.23",
     "babel-eslint": "^11.0.0-beta.2",

--- a/packages/generator-single-spa/src/react/templates/package.json
+++ b/packages/generator-single-spa/src/react/templates/package.json
@@ -19,7 +19,7 @@
     "@babel/plugin-transform-runtime": "^7.8.3",
     "@babel/preset-env": "^7.7.6",
     "@babel/preset-react": "^7.7.4",
-    "@babel/runtime": "^7.0.0-beta.3",
+    "@babel/runtime": "^7.8.7",
     "@testing-library/react": "^9.4.0",
     "@types/jest": "^24.0.23",
     "babel-eslint": "^11.0.0-beta.2",

--- a/packages/generator-single-spa/src/react/templates/package.json
+++ b/packages/generator-single-spa/src/react/templates/package.json
@@ -16,6 +16,7 @@
   },
   "devDependencies": {
     "@babel/core": "^7.7.5",
+    "@babel/plugin-transform-runtime": "^7.8.3",
     "@babel/preset-env": "^7.7.6",
     "@babel/preset-react": "^7.7.4",
     "@testing-library/react": "^9.4.0",

--- a/packages/generator-single-spa/src/root-config/templates/.babelrc
+++ b/packages/generator-single-spa/src/root-config/templates/.babelrc
@@ -1,5 +1,8 @@
 {
   "presets": [
     "@babel/preset-env"
+  ],
+  "plugins": [
+    "@babel/plugin-transform-runtime"
   ]
 }

--- a/packages/generator-single-spa/src/root-config/templates/.babelrc
+++ b/packages/generator-single-spa/src/root-config/templates/.babelrc
@@ -3,6 +3,9 @@
     "@babel/preset-env"
   ],
   "plugins": [
-    "@babel/plugin-transform-runtime"
+    ["@babel/plugin-transform-runtime", {
+      "useESModules": true,
+      "regenerator": false
+    }]
   ]
 }

--- a/packages/generator-single-spa/src/root-config/templates/package.json
+++ b/packages/generator-single-spa/src/root-config/templates/package.json
@@ -15,6 +15,7 @@
     "@babel/core": "^7.7.4",
     "@babel/plugin-transform-runtime": "^7.8.3",
     "@babel/preset-env": "^7.7.4",
+    "@babel/runtime": "^7.0.0-beta.3",
     "@types/systemjs": "^6.1.0",
     "babel-eslint": "^11.0.0-beta.2",
     "babel-loader": "^8.0.6",

--- a/packages/generator-single-spa/src/root-config/templates/package.json
+++ b/packages/generator-single-spa/src/root-config/templates/package.json
@@ -15,7 +15,7 @@
     "@babel/core": "^7.7.4",
     "@babel/plugin-transform-runtime": "^7.8.3",
     "@babel/preset-env": "^7.7.4",
-    "@babel/runtime": "^7.0.0-beta.3",
+    "@babel/runtime": "^7.8.7",
     "@types/systemjs": "^6.1.0",
     "babel-eslint": "^11.0.0-beta.2",
     "babel-loader": "^8.0.6",

--- a/packages/generator-single-spa/src/root-config/templates/package.json
+++ b/packages/generator-single-spa/src/root-config/templates/package.json
@@ -13,6 +13,7 @@
   },
   "devDependencies": {
     "@babel/core": "^7.7.4",
+    "@babel/plugin-transform-runtime": "^7.8.3",
     "@babel/preset-env": "^7.7.4",
     "@types/systemjs": "^6.1.0",
     "babel-eslint": "^11.0.0-beta.2",

--- a/packages/generator-single-spa/src/util-module/templates/.babelrc
+++ b/packages/generator-single-spa/src/util-module/templates/.babelrc
@@ -3,5 +3,6 @@
     "@babel/preset-env"
   ],
   "plugins": [
+    "@babel/plugin-transform-runtime"
   ]
 }

--- a/packages/generator-single-spa/src/util-module/templates/.babelrc
+++ b/packages/generator-single-spa/src/util-module/templates/.babelrc
@@ -3,6 +3,9 @@
     "@babel/preset-env"
   ],
   "plugins": [
-    "@babel/plugin-transform-runtime"
+    ["@babel/plugin-transform-runtime", {
+      "useESModules": true,
+      "regenerator": false
+    }]
   ]
 }

--- a/packages/generator-single-spa/src/util-module/templates/package.json
+++ b/packages/generator-single-spa/src/util-module/templates/package.json
@@ -18,6 +18,7 @@
     "@babel/core": "^7.7.5",
     "@babel/plugin-transform-runtime": "^7.8.3",
     "@babel/preset-env": "^7.7.6",
+    "@babel/runtime": "^7.0.0-beta.3",
     "@types/jest": "^24.0.23",
     "babel-eslint": "^11.0.0-beta.2",
     "babel-jest": "^24.9.0",

--- a/packages/generator-single-spa/src/util-module/templates/package.json
+++ b/packages/generator-single-spa/src/util-module/templates/package.json
@@ -16,6 +16,7 @@
   },
   "devDependencies": {
     "@babel/core": "^7.7.5",
+    "@babel/plugin-transform-runtime": "^7.8.3",
     "@babel/preset-env": "^7.7.6",
     "@types/jest": "^24.0.23",
     "babel-eslint": "^11.0.0-beta.2",

--- a/packages/generator-single-spa/src/util-module/templates/package.json
+++ b/packages/generator-single-spa/src/util-module/templates/package.json
@@ -18,7 +18,7 @@
     "@babel/core": "^7.7.5",
     "@babel/plugin-transform-runtime": "^7.8.3",
     "@babel/preset-env": "^7.7.6",
-    "@babel/runtime": "^7.0.0-beta.3",
+    "@babel/runtime": "^7.8.7",
     "@types/jest": "^24.0.23",
     "babel-eslint": "^11.0.0-beta.2",
     "babel-jest": "^24.9.0",


### PR DESCRIPTION
See #17. This avoids the `regeneratorRuntime` problems and also saves bundle size