### PR TITLE
Updated root-config.js so that the template will work out of the box.

### DIFF
--- a/packages/generator-single-spa/src/root-config/generator-root-config.js
+++ b/packages/generator-single-spa/src/root-config/generator-root-config.js
@@ -42,6 +42,7 @@ module.exports = class SingleSpaRootConfigGenerator extends Generator {
         type: "input",
         name: "orgName",
         message: "Organization name (use lowercase and dashes)",
+        default: "react-mf"
       },
     ])
 
@@ -49,28 +50,28 @@ module.exports = class SingleSpaRootConfigGenerator extends Generator {
       this.templatePath('.babelrc'),
       this.destinationPath('.babelrc'),
       templateOptions,
-      {delimiter: '?'}
+      { delimiter: '?' }
     )
 
     this.fs.copyTpl(
       this.templatePath('.eslintrc'),
       this.destinationPath('.eslintrc'),
       templateOptions,
-      {delimiter: '?'}
+      { delimiter: '?' }
     )
 
     this.fs.copyTpl(
       this.templatePath('.prettierignore'),
       this.destinationPath('.prettierignore'),
       templateOptions,
-      {delimiter: '?'}
+      { delimiter: '?' }
     )
 
     this.fs.copyTpl(
       this.templatePath(),
       this.destinationPath(),
       templateOptions,
-      {delimiter: '?'}
+      { delimiter: '?' }
     )
   }
   install() {

--- a/packages/generator-single-spa/src/root-config/generator-root-config.js
+++ b/packages/generator-single-spa/src/root-config/generator-root-config.js
@@ -42,7 +42,7 @@ module.exports = class SingleSpaRootConfigGenerator extends Generator {
         type: "input",
         name: "orgName",
         message: "Organization name (use lowercase and dashes)",
-        default: "react-mf"
+        default: "org-name"
       },
     ])
 

--- a/packages/generator-single-spa/src/root-config/templates/src/root-config.js
+++ b/packages/generator-single-spa/src/root-config/templates/src/root-config.js
@@ -2,8 +2,8 @@ import { registerApplication, start } from "single-spa";
 import * as isActive from "./activity-functions";
 
 registerApplication(
-  "@<?- orgName ?>/navbar",
-  () => System.import("@<?- orgName ?>/navbar"),
+  "@react-mf/navbar",
+  () => System.import("@react-mf/navbar"),
   isActive.navbar
 );
 

--- a/packages/generator-single-spa/src/root-config/templates/src/root-config.js
+++ b/packages/generator-single-spa/src/root-config/templates/src/root-config.js
@@ -2,8 +2,8 @@ import { registerApplication, start } from "single-spa";
 import * as isActive from "./activity-functions";
 
 registerApplication(
-  "@react-mf/navbar",
-  () => System.import("@react-mf/navbar"),
+  "@<?- orgName ?>/navbar",
+  () => System.import("@<?- orgName ?>/navbar"),
   isActive.navbar
 );
 


### PR DESCRIPTION
Issue: When running npx create-single-spa and going down the root config path the application does not work out of the box as it implies. 

![pr2](https://user-images.githubusercontent.com/5688067/75947601-93f1e480-5e66-11ea-9a2a-c6602d1a5fa3.png)

![pr](https://user-images.githubusercontent.com/5688067/75947608-994f2f00-5e66-11ea-9715-7050b9bf9a8b.png)


Solution:
Hard code navbar to be the same as is listed in the given import-map. 