### PR TITLE
Allow for local https development

### DIFF
--- a/packages/generator-single-spa/src/root-config/templates/src/index.ejs
+++ b/packages/generator-single-spa/src/root-config/templates/src/index.ejs
@@ -11,7 +11,7 @@
   <script type="systemjs-importmap">
     {
       "imports": {
-        "@<?- orgName ?>/root-config": "http://localhost:9000/root-config.js"
+        "@<?- orgName ?>/root-config": "//localhost:9000/root-config.js"
       }
     }
   </script>


### PR DESCRIPTION
Allow for local https development - you need https when overriding the js file on deployed envs, but it's annoying to not be able to load up the js file from your local html file because it assumes https instead of http.