### PR TITLE
Add initial CSP meta

### DIFF
--- a/packages/generator-single-spa/src/root-config/templates/src/index.ejs
+++ b/packages/generator-single-spa/src/root-config/templates/src/index.ejs
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta http-equiv="X-UA-Compatible" content="ie=edge">
   <title>Root Config</title>
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'unsafe-inline' unpkg.com cdn.jsdelivr.net; object-src 'self';">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'unsafe-inline' unpkg.com cdn.jsdelivr.net; object-src 'none';">
   <meta name="importmap-type" content="systemjs-importmap" />
   <script type="systemjs-importmap" src="https://storage.googleapis.com/react.microfrontends.app/importmap.json"></script>
   <% if (isLocal) { %>

--- a/packages/generator-single-spa/src/root-config/templates/src/index.ejs
+++ b/packages/generator-single-spa/src/root-config/templates/src/index.ejs
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta http-equiv="X-UA-Compatible" content="ie=edge">
   <title>Root Config</title>
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'unsafe-inline' unpkg.com cdn.jsdelivr.net; object-src 'self';">
   <meta name="importmap-type" content="systemjs-importmap" />
   <script type="systemjs-importmap" src="https://storage.googleapis.com/react.microfrontends.app/importmap.json"></script>
   <% if (isLocal) { %>


### PR DESCRIPTION
This is an initial pass at adding the CSP header. Resolves #36 

I ran this CSP on https://csp-evaluator.withgoogle.com/ to check for best practices since I'm not very familiar with CSP. 

- Allows unpkg and jsdelivr URLs though this is what the csp-evaluator has to say:
    > cdn.jsdelivr.net is known to host Angular libraries which allow to bypass this CSP.
    
    and the above would also apply to unpkg
- set `object-src` policy to `'none'` as recommended by csp-evaluator
- `script-src` needs `'unsafe-inline'` because (I believe) then the inline importmaps wouldn't work, as well as any inline script tags (at least not without a nonce)
- I have to wonder if `script-src` should also have `'strict-dynamic'` since that would allow a "script to load additional scripts via non-"parser-inserted" script elements (for example document.createElement('script'); is allowed)." which __system.js__ might use. 