### PR TITLE
exploring adding an explanitory comment to the file

### DIFF
--- a/packages/generator-single-spa/src/react/templates/src/set-public-path.js
+++ b/packages/generator-single-spa/src/react/templates/src/set-public-path.js
@@ -5,4 +5,4 @@ import { setPublicPath } from "systemjs-webpack-interop";
  * https://single-spa.js.org/docs/faq/#code-splits
  */
 
-setPublicPath('@<%= orgName %>/<%= projectName %>');
+setPublicPath("@<%= orgName %>/<%= projectName %>");

--- a/packages/generator-single-spa/src/react/templates/src/set-public-path.js
+++ b/packages/generator-single-spa/src/react/templates/src/set-public-path.js
@@ -1,3 +1,8 @@
 import { setPublicPath } from "systemjs-webpack-interop";
+/* This dynamically sets the webpack public path so that code splits work properly. See related:
+ * https://github.com/joeldenning/systemjs-webpack-interop#what-is-this
+ * https://webpack.js.org/guides/public-path/#on-the-fly
+ * https://single-spa.js.org/docs/faq/#code-splits
+ */
 
 setPublicPath('@<%= orgName %>/<%= projectName %>');

--- a/packages/generator-single-spa/src/util-module/templates/src/set-public-path.js
+++ b/packages/generator-single-spa/src/util-module/templates/src/set-public-path.js
@@ -1,17 +1,8 @@
 import { setPublicPath } from "systemjs-webpack-interop";
+/* This dynamically sets the webpack public path so that code splits work properly. See related:
+ * https://github.com/joeldenning/systemjs-webpack-interop#what-is-this
+ * https://webpack.js.org/guides/public-path/#on-the-fly
+ * https://single-spa.js.org/docs/faq/#code-splits
+ */
 
-setPublicPath('@<%= orgName %>/<%= projectName %>');
-// This file exists to solve a problem with how webpack loads code splits
-// Webpack assumes that it can pull splits from the url origin
-// That assumption doesn't hold true in a microfrontend approach
-// ex:
-// App1 running at the following url
-// https://myapp.com/app1
-// and specified in the import map at https://aws/app1/321478917398127dsasf3/app1.js
-// by default webpack would try to load app1 code splits from https://myapp.com/
-// instead of the correct url specified in your import map
-// 
-// systemjs-webpack-interop uses the url in your import map as the base for all code splits
-// in the example above we're setting the root area where all code splits load as
-// https://aws/app1/321478917398127dsasf3/ so that the vendors bundle is loaded
-// from the correct url
+setPublicPath("@<%= orgName %>/<%= projectName %>");

--- a/packages/generator-single-spa/src/util-module/templates/src/set-public-path.js
+++ b/packages/generator-single-spa/src/util-module/templates/src/set-public-path.js
@@ -1,3 +1,17 @@
 import { setPublicPath } from "systemjs-webpack-interop";
 
 setPublicPath('@<%= orgName %>/<%= projectName %>');
+// This file exists to solve a problem with how webpack loads code splits
+// Webpack assumes that it can pull splits from the url origin
+// That assumption doesn't hold true in a microfrontend approach
+// ex:
+// App1 running at the following url
+// https://myapp.com/app1
+// and specified in the import map at https://aws/app1/321478917398127dsasf3/app1.js
+// by default webpack would try to load app1 code splits from https://myapp.com/
+// instead of the correct url specified in your import map
+// 
+// systemjs-webpack-interop uses the url in your import map as the base for all code splits
+// in the example above we're setting the root area where all code splits load as
+// https://aws/app1/321478917398127dsasf3/ so that the vendors bundle is loaded
+// from the correct url


### PR DESCRIPTION
I've seen a few questions about asking why the CLI generates this file

https://single-spa.slack.com/archives/C8R6U7MT7/p1586204715291500

and a few I've had internally at workfront. I just wanted to discuss if we should add _something like_ this to help answer some of those questions