### PR TITLE
Fixing issue with root config pre-commit

### DIFF
--- a/packages/generator-single-spa/src/root-config/templates/package.json
+++ b/packages/generator-single-spa/src/root-config/templates/package.json
@@ -19,6 +19,7 @@
     "@types/systemjs": "^6.1.0",
     "babel-eslint": "^11.0.0-beta.2",
     "babel-loader": "^8.0.6",
+    "concurrently": "^5.1.0",
     "eslint": "^6.7.2",
     "eslint-config-important-stuff": "^1.1.0",
     "eslint-config-prettier": "^6.7.0",

--- a/packages/generator-single-spa/src/root-config/templates/package.json
+++ b/packages/generator-single-spa/src/root-config/templates/package.json
@@ -8,7 +8,7 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "pretty-quick --staged && eslint src"
+      "pre-commit": "pretty-quick --staged && concurrently <%= packageManager %>:test <%= packageManager %>:lint"
     }
   },
   "devDependencies": {


### PR DESCRIPTION
`eslint src` doesn't work in typescript projects, but `yarn lint` does