### PR TITLE
Making urlRerouteOnly the default for root configs

### DIFF
--- a/packages/generator-single-spa/src/root-config/templates/src/root-config.js
+++ b/packages/generator-single-spa/src/root-config/templates/src/root-config.js
@@ -7,4 +7,6 @@ registerApplication({
   activeWhen: isActive.navbar,
 });
 
-start();
+start({
+  urlRerouteOnly: true,
+});


### PR DESCRIPTION
urlRerouteOnly was introduced in https://github.com/single-spa/single-spa/releases/tag/v5.2.0 and is something I think could make sense to turn on by default as a major release of single-spa. For now, though, we can just turn it on by default in the CLI's generated files