### PR TITLE
 Adding shared dependencies import map to root config. Resolves #23. 

### DIFF
--- a/packages/generator-single-spa/src/root-config/templates/src/index.ejs
+++ b/packages/generator-single-spa/src/root-config/templates/src/index.ejs
@@ -12,7 +12,14 @@
   <meta http-equiv="Content-Security-Policy" content="default-src 'self' https: localhost:*; script-src 'unsafe-inline' https: localhost:*; connect-src https: localhost:* ws://localhost:*; style-src 'unsafe-inline' https:; object-src 'none';">
   <meta name="importmap-type" content="systemjs-importmap" />
 
-  <!-- Shared dependencies go into this import map -->
+  <!-- Shared dependencies go into this import map. Your shared dependencies must be of one of the following formats:
+
+    1. System.register (preferred when possible) - https://github.com/systemjs/systemjs/blob/master/docs/system-register.md
+    2. UMD - https://github.com/umdjs/umd
+    3. Global variable
+
+    More information about shared dependencies can be found at https://single-spa.js.org/docs/recommended-setup#sharing-with-import-maps.
+  -->
   <script type="systemjs-importmap">
     {
       "imports": {

--- a/packages/generator-single-spa/src/root-config/templates/src/index.ejs
+++ b/packages/generator-single-spa/src/root-config/templates/src/index.ejs
@@ -11,8 +11,19 @@
   -->
   <meta http-equiv="Content-Security-Policy" content="default-src 'self' https: localhost:*; script-src 'unsafe-inline' https: localhost:*; connect-src https: localhost:* ws://localhost:*; style-src 'unsafe-inline' https:; object-src 'none';">
   <meta name="importmap-type" content="systemjs-importmap" />
+
+  <!-- Shared dependencies go into this import map -->
+  <script type="systemjs-importmap">
+    {
+      "imports": {
+        "single-spa": "https://cdn.jsdelivr.net/npm/single-spa@5.5.0/lib/system/single-spa.min.js"
+      }
+    }
+  </script>
+
   <!-- Add your organization's prod import map URL to this script's src  -->
   <!-- <script type="systemjs-importmap" src="/importmap.json"></script> -->
+
   <% if (isLocal) { %>
   <script type="systemjs-importmap">
     {


### PR DESCRIPTION
See #23. cc @filoxo @Sauloxd. This has been broken for a few weeks now so I figure it would be good to get this merged in and published even if we end up making it fancier later.