### PR TITLE
Removing redundant root config webpack config options.

### DIFF
--- a/packages/generator-single-spa/src/root-config/templates/webpack.config.js
+++ b/packages/generator-single-spa/src/root-config/templates/webpack.config.js
@@ -13,10 +13,6 @@ module.exports = (webpackConfigEnv) => {
     // modify the webpack config however you'd like to by adding to this object
     devServer: {
       historyApiFallback: true,
-      headers: {
-        "Access-Control-Allow-Origin": "*",
-      },
-      disableHostCheck: true,
     },
     plugins: [
       new HtmlWebpackPlugin({


### PR DESCRIPTION
These options are already enabled in webpack-config-single-spa, which is now used by root-configs.