### PR TITLE
Disabling ForkTsCheckerWebpackPlugin during analyze. Resolves #87.

### DIFF
--- a/packages/webpack-config-single-spa-ts/lib/webpack-config-single-spa-ts.js
+++ b/packages/webpack-config-single-spa-ts/lib/webpack-config-single-spa-ts.js
@@ -16,7 +16,11 @@ const modifyConfig = (opts, webpackConfig) => {
       ".js",
       opts.framework === "react" ? ".tsx" : ".ts"
     ),
-    plugins: [new ForkTsCheckerWebpackPlugin({ typescript: typescriptPath })],
+    plugins: [
+      opts.webpackConfigEnv && opts.webpackConfigEnv.analyze
+        ? false
+        : new ForkTsCheckerWebpackPlugin({ typescript: typescriptPath }),
+    ].filter(Boolean),
     resolve: {
       extensions: [".ts", ".tsx"],
     },


### PR DESCRIPTION
See #87. When running webpack bundle analyzer, we don't need to check the types.