### PR TITLE
Ignoring yarn-error.log in prettier.

### DIFF
--- a/packages/generator-single-spa/src/react/templates/.prettierignore
+++ b/packages/generator-single-spa/src/react/templates/.prettierignore
@@ -1,5 +1,6 @@
 .gitignore
 .prettierignore
 yarn.lock
+yarn-error.log
 package-lock.json
 dist

--- a/packages/generator-single-spa/src/root-config/templates/.prettierignore
+++ b/packages/generator-single-spa/src/root-config/templates/.prettierignore
@@ -1,6 +1,7 @@
 .gitignore
 .prettierignore
 yarn.lock
+yarn-error.log
 package-lock.json
 LICENSE
 *.ejs

--- a/packages/generator-single-spa/src/util-module/templates/.prettierignore
+++ b/packages/generator-single-spa/src/util-module/templates/.prettierignore
@@ -1,5 +1,6 @@
 .gitignore
 .prettierignore
 yarn.lock
+yarn-error.log
 package-lock.json
 dist

--- a/packages/single-spa-welcome/.prettierignore
+++ b/packages/single-spa-welcome/.prettierignore
@@ -1,5 +1,6 @@
 .gitignore
 .prettierignore
 yarn.lock
+yarn-error.log
 package-lock.json
 dist


### PR DESCRIPTION
`yarn-error.log` is created when yarn install or yarn scripts fail. That file cannot be processed by prettier and should be ignored.