### PR TITLE
fix eslint issue with typescript. Resolves #139

### DIFF
--- a/packages/generator-single-spa/src/common-templates/typescript/package.json
+++ b/packages/generator-single-spa/src/common-templates/typescript/package.json
@@ -1,7 +1,7 @@
 {
   "devDependencies": {
     "@babel/preset-typescript": "^7.9.0",
-    "eslint-config-ts-react-important-stuff": "^2.0.0",
+    "eslint-config-ts-important-stuff": "^1.0.0",
     "typescript": "^3.8.3",
     "webpack-config-single-spa-ts": "^1.4.2",
     "ts-config-single-spa": "^1.7.0"

--- a/packages/generator-single-spa/src/react/generator-single-spa-react.js
+++ b/packages/generator-single-spa/src/react/generator-single-spa-react.js
@@ -80,7 +80,14 @@ module.exports = class SingleSpaReactGenerator extends Generator {
       // Extend with react-specific package json for typescript
       this.fs.extendJSON(
         this.destinationPath("package.json"),
-        this.fs.readJSON(this.templatePath("typescript/package.json"))
+        this.fs.readJSON(this.templatePath("typescript/package.json")),
+        (key, value) => {
+          if (key === "devDependencies") {
+            // Remove standard eslint configuration in favor of react specific
+            delete value["eslint-config-ts-important-stuff"];
+          }
+          return value;
+        }
       );
     }
   }

--- a/packages/generator-single-spa/src/react/templates/typescript/package.json
+++ b/packages/generator-single-spa/src/react/templates/typescript/package.json
@@ -1,5 +1,6 @@
 {
   "devDependencies": {
+    "eslint-config-ts-react-important-stuff": "^2.0.0",
     "webpack-config-single-spa-react-ts": "^1.4.2"
   }
 }


### PR DESCRIPTION
This is my attempt at fixing the problem in #139

I have tried with creating a new project and it indeed works for the utils module

When I run tests I have a problem with the package.json that I modified.

```
yarn run v1.22.4
$ jest
Error: Cannot parse /Users/spicciani/dev/microfrontend/create-single-spa/packages/generator-single-spa/src/util-module/templates/package.json as JSON: Unexpected token < in JSON at position 1033
    at Object.worker (/Users/spicciani/dev/microfrontend/create-single-spa/node_modules/jest-haste-map/build/worker.js:146:13)
    at execFunction (/Users/spicciani/dev/microfrontend/create-single-spa/node_modules/jest-worker/build/workers/processChild.js:183:17)
    at execHelper (/Users/spicciani/dev/microfrontend/create-single-spa/node_modules/jest-worker/build/workers/processChild.js:167:5)
    at execMethod (/Users/spicciani/dev/microfrontend/create-single-spa/node_modules/jest-worker/build/workers/processChild.js:171:5)
    at process.messageListener (/Users/spicciani/dev/microfrontend/create-single-spa/node_modules/jest-worker/build/workers/processChild.js:89:7)
    at process.emit (events.js:315:20)
    at emit (internal/child_process.js:906:12)
    at processTicksAndRejections (internal/process/task_queues.js:85:21)
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

I think that is caused by `packages/generator-single-spa/test/util-module.test.js` but I cannot fix it. 
