### PR TITLE
fix: util-module eslint config

### DIFF
--- a/packages/generator-single-spa/src/util-module/generator-single-spa-util-module.js
+++ b/packages/generator-single-spa/src/util-module/generator-single-spa-util-module.js
@@ -121,7 +121,7 @@ module.exports = class SingleSpaUtilModuleGenerator extends Generator {
       this.options
     );
     this.fs.copyTpl(
-      this.templatePath(".eslintrc"),
+      this.templatePath(".eslintrc.ejs"),
       this.destinationPath(".eslintrc"),
       this.options
     );

--- a/packages/generator-single-spa/src/util-module/templates/.eslintrc
+++ b/packages/generator-single-spa/src/util-module/templates/.eslintrc
@@ -1,4 +1,0 @@
-{
-  "extends": ["important-stuff", "plugin:prettier/recommended"],
-  "parser": "babel-eslint"
-}

--- a/packages/generator-single-spa/src/util-module/templates/.eslintrc.ejs
+++ b/packages/generator-single-spa/src/util-module/templates/.eslintrc.ejs
@@ -1,0 +1,7 @@
+{
+  "extends": [
+    <%if (typescript) { %>"ts-important-stuff",<%} else { %>"important-stuff",<% } %>
+    "plugin:prettier/recommended"
+  ],
+  "parser": "babel-eslint"
+}


### PR DESCRIPTION
fixes issue where generating util-module with typescript enabled does not have `no-undef` rule via `eslint-config-ts-important-stuff`