### PR TITLE
Fix/missing org name

### DIFF
--- a/packages/generator-single-spa/package.json
+++ b/packages/generator-single-spa/package.json
@@ -8,7 +8,7 @@
     "src"
   ],
   "scripts": {
-    "test": "jest --testPathIgnorePatterns templates"
+    "test": "jest"
   },
   "version": "1.11.0",
   "main": "src/generator-single-spa.js",
@@ -22,5 +22,10 @@
     "jest": "^24.9.0",
     "yeoman-assert": "^3.1.1",
     "yeoman-test": "^2.0.0"
+  },
+  "jest": {
+    "testPathIgnorePatterns": [
+      "templates"
+    ]
   }
 }

--- a/packages/generator-single-spa/src/naming.js
+++ b/packages/generator-single-spa/src/naming.js
@@ -1,0 +1,5 @@
+const NAMING_CONVENTION = /^[a-z\-]*$/;
+
+module.exports = function isValidName(name) {
+  return NAMING_CONVENTION.test(name);
+};

--- a/packages/generator-single-spa/src/react/generator-single-spa-react.js
+++ b/packages/generator-single-spa/src/react/generator-single-spa-react.js
@@ -20,7 +20,7 @@ module.exports = class SingleSpaReactGenerator extends Generator {
       type: String,
     });
   }
-  async createPackageJson() {
+  async getOptions() {
     if (!this.options.packageManager) {
       this.options.packageManager = (
         await this.prompt([
@@ -47,6 +47,35 @@ module.exports = class SingleSpaReactGenerator extends Generator {
       ).typescript;
     }
 
+    while (!this.options.orgName) {
+      let { orgName } = await this.prompt([
+        {
+          type: "input",
+          name: "orgName",
+          message: "Organization name (use lowercase and dashes)",
+        },
+      ]);
+
+      orgName = orgName && orgName.trim();
+      if (!orgName) console.log(chalk.red("orgName must be provided!"));
+      this.options.orgName = orgName;
+    }
+
+    if (!this.options.projectName) {
+      this.options.projectName = (
+        await this.prompt([
+          {
+            type: "input",
+            name: "projectName",
+            message: "Project name (use lowercase and dashes)",
+          },
+        ])
+      ).projectName;
+    }
+
+    this.options.framework = "react";
+  }
+  async createPackageJson() {
     const packageJsonTemplate = await fs.readFile(
       this.templatePath("package.json"),
       { encoding: "utf-8" }
@@ -92,32 +121,6 @@ module.exports = class SingleSpaReactGenerator extends Generator {
     }
   }
   async copyOtherFiles() {
-    if (!this.options.orgName) {
-      this.options.orgName = (
-        await this.prompt([
-          {
-            type: "input",
-            name: "orgName",
-            message: "Organization name (use lowercase and dashes)",
-          },
-        ])
-      ).orgName;
-    }
-
-    if (!this.options.projectName) {
-      this.options.projectName = (
-        await this.prompt([
-          {
-            type: "input",
-            name: "projectName",
-            message: "Project name (use lowercase and dashes)",
-          },
-        ])
-      ).projectName;
-    }
-
-    this.options.framework = "react";
-
     const srcFileExtension = this.options.typescript ? "tsx" : "js";
 
     this.fs.copyTpl(

--- a/packages/generator-single-spa/src/react/generator-single-spa-react.js
+++ b/packages/generator-single-spa/src/react/generator-single-spa-react.js
@@ -2,6 +2,7 @@ const Generator = require("yeoman-generator");
 const ejs = require("ejs");
 const fs = require("fs").promises;
 const chalk = require("chalk");
+const isValidName = require("../naming");
 
 module.exports = class SingleSpaReactGenerator extends Generator {
   constructor(args, opts) {
@@ -58,6 +59,8 @@ module.exports = class SingleSpaReactGenerator extends Generator {
 
       orgName = orgName && orgName.trim();
       if (!orgName) console.log(chalk.red("orgName must be provided!"));
+      if (!isValidName(orgName))
+        console.log(chalk.red("orgName must use lowercase and dashes!"));
       this.options.orgName = orgName;
     }
 
@@ -72,6 +75,8 @@ module.exports = class SingleSpaReactGenerator extends Generator {
 
       projectName = projectName && projectName.trim();
       if (!projectName) console.log(chalk.red("projectName must be provided!"));
+      if (!isValidName(projectName))
+        console.log(chalk.red("projectName must use lowercase and dashes!"));
       this.options.projectName = projectName;
     }
 

--- a/packages/generator-single-spa/src/react/generator-single-spa-react.js
+++ b/packages/generator-single-spa/src/react/generator-single-spa-react.js
@@ -65,7 +65,7 @@ module.exports = class SingleSpaReactGenerator extends Generator {
     }
 
     while (!this.options.projectName) {
-      let { projectName } = await await this.prompt([
+      let { projectName } = await this.prompt([
         {
           type: "input",
           name: "projectName",

--- a/packages/generator-single-spa/src/react/generator-single-spa-react.js
+++ b/packages/generator-single-spa/src/react/generator-single-spa-react.js
@@ -61,16 +61,18 @@ module.exports = class SingleSpaReactGenerator extends Generator {
       this.options.orgName = orgName;
     }
 
-    if (!this.options.projectName) {
-      this.options.projectName = (
-        await this.prompt([
-          {
-            type: "input",
-            name: "projectName",
-            message: "Project name (use lowercase and dashes)",
-          },
-        ])
-      ).projectName;
+    while (!this.options.projectName) {
+      let { projectName } = await await this.prompt([
+        {
+          type: "input",
+          name: "projectName",
+          message: "Project name (use lowercase and dashes)",
+        },
+      ]);
+
+      projectName = projectName && projectName.trim();
+      if (!projectName) console.log(chalk.red("projectName must be provided!"));
+      this.options.projectName = projectName;
     }
 
     this.options.framework = "react";

--- a/packages/generator-single-spa/src/root-config/generator-root-config.js
+++ b/packages/generator-single-spa/src/root-config/generator-root-config.js
@@ -64,6 +64,23 @@ module.exports = class SingleSpaRootConfigGenerator extends Generator {
       ).layout;
     }
 
+    while (!this.options.orgName) {
+      let { orgName } = await this.prompt([
+        {
+          type: "input",
+          name: "orgName",
+          message: "Organization name (use lowercase and dashes)",
+        },
+      ]);
+
+      orgName = orgName && orgName.trim();
+      if (!orgName) console.log(chalk.red("orgName must be provided!"));
+      this.options.orgName = orgName;
+    }
+
+    this.options.framework = "none";
+  }
+  async copyFiles() {
     const packageJsonTemplate = await fs.readFile(
       this.templatePath("package.json"),
       { encoding: "utf-8" }
@@ -94,21 +111,6 @@ module.exports = class SingleSpaRootConfigGenerator extends Generator {
         )
       );
     }
-  }
-  async copyFiles() {
-    if (!this.options.orgName) {
-      this.options.orgName = (
-        await this.prompt([
-          {
-            type: "input",
-            name: "orgName",
-            message: "Organization name (use lowercase and dashes)",
-          },
-        ])
-      ).orgName;
-    }
-
-    this.options.framework = "none";
 
     const srcFileExtension = this.options.typescript ? "ts" : "js";
 

--- a/packages/generator-single-spa/src/root-config/generator-root-config.js
+++ b/packages/generator-single-spa/src/root-config/generator-root-config.js
@@ -2,6 +2,7 @@ const Generator = require("yeoman-generator");
 const fs = require("fs").promises;
 const ejs = require("ejs");
 const chalk = require("chalk");
+const isValidName = require("../naming");
 
 module.exports = class SingleSpaRootConfigGenerator extends Generator {
   constructor(args, opts) {
@@ -75,6 +76,8 @@ module.exports = class SingleSpaRootConfigGenerator extends Generator {
 
       orgName = orgName && orgName.trim();
       if (!orgName) console.log(chalk.red("orgName must be provided!"));
+      if (!isValidName(orgName))
+        console.log(chalk.red("orgName must use lowercase and dashes!"));
       this.options.orgName = orgName;
     }
 

--- a/packages/generator-single-spa/src/svelte/generator-single-spa-svelte.js
+++ b/packages/generator-single-spa/src/svelte/generator-single-spa-svelte.js
@@ -2,6 +2,7 @@ const Generator = require("yeoman-generator");
 const ejs = require("ejs");
 const fs = require("fs").promises;
 const chalk = require("chalk");
+const isValidName = require("../naming");
 
 module.exports = class SingleSpaSvelteGenerator extends Generator {
   constructor(args, opts) {
@@ -58,6 +59,8 @@ module.exports = class SingleSpaSvelteGenerator extends Generator {
 
       orgName = orgName && orgName.trim();
       if (!orgName) console.log(chalk.red("orgName must be provided!"));
+      if (!isValidName(orgName))
+        console.log(chalk.red("orgName must use lowercase and dashes!"));
       this.options.orgName = orgName;
     }
 
@@ -72,6 +75,9 @@ module.exports = class SingleSpaSvelteGenerator extends Generator {
 
       projectName = projectName && projectName.trim();
       if (!projectName) console.log(chalk.red("projectName must be provided!"));
+      if (!isValidName(projectName))
+        console.log(chalk.red("projectName must use lowercase and dashes!"));
+
       this.options.projectName = projectName;
     }
 

--- a/packages/generator-single-spa/src/svelte/generator-single-spa-svelte.js
+++ b/packages/generator-single-spa/src/svelte/generator-single-spa-svelte.js
@@ -47,16 +47,18 @@ module.exports = class SingleSpaSvelteGenerator extends Generator {
     //   ).typescript;
     // }
 
-    if (!this.options.orgName) {
-      this.options.orgName = (
-        await this.prompt([
-          {
-            type: "input",
-            name: "orgName",
-            message: "Organization name (use lowercase and dashes)",
-          },
-        ])
-      ).orgName;
+    while (!this.options.orgName) {
+      let { orgName } = await this.prompt([
+        {
+          type: "input",
+          name: "orgName",
+          message: "Organization name (use lowercase and dashes)",
+        },
+      ]);
+
+      orgName = orgName && orgName.trim();
+      if (!orgName) console.log(chalk.red("orgName must be provided!"));
+      this.options.orgName = orgName;
     }
 
     if (!this.options.projectName) {

--- a/packages/generator-single-spa/src/svelte/generator-single-spa-svelte.js
+++ b/packages/generator-single-spa/src/svelte/generator-single-spa-svelte.js
@@ -61,16 +61,18 @@ module.exports = class SingleSpaSvelteGenerator extends Generator {
       this.options.orgName = orgName;
     }
 
-    if (!this.options.projectName) {
-      this.options.projectName = (
-        await this.prompt([
-          {
-            type: "input",
-            name: "projectName",
-            message: "Project name (use lowercase and dashes)",
-          },
-        ])
-      ).projectName;
+    while (!this.options.projectName) {
+      let { projectName } = await await this.prompt([
+        {
+          type: "input",
+          name: "projectName",
+          message: "Project name (use lowercase and dashes)",
+        },
+      ]);
+
+      projectName = projectName && projectName.trim();
+      if (!projectName) console.log(chalk.red("projectName must be provided!"));
+      this.options.projectName = projectName;
     }
 
     this.options.framework = "svelte";

--- a/packages/generator-single-spa/src/svelte/generator-single-spa-svelte.js
+++ b/packages/generator-single-spa/src/svelte/generator-single-spa-svelte.js
@@ -65,7 +65,7 @@ module.exports = class SingleSpaSvelteGenerator extends Generator {
     }
 
     while (!this.options.projectName) {
-      let { projectName } = await await this.prompt([
+      let { projectName } = await this.prompt([
         {
           type: "input",
           name: "projectName",

--- a/packages/generator-single-spa/src/svelte/generator-single-spa-svelte.js
+++ b/packages/generator-single-spa/src/svelte/generator-single-spa-svelte.js
@@ -72,6 +72,8 @@ module.exports = class SingleSpaSvelteGenerator extends Generator {
         ])
       ).projectName;
     }
+
+    this.options.framework = "svelte";
   }
   async createPackageJson() {
     const packageJsonTemplate = await fs.readFile(
@@ -102,8 +104,6 @@ module.exports = class SingleSpaSvelteGenerator extends Generator {
     // }
   }
   async copyOtherFiles() {
-    this.options.framework = "svelte";
-
     const srcFileExtension = /* this.options.typescript ? "tsx" : */ "js";
 
     this.fs.copyTpl(

--- a/packages/generator-single-spa/src/svelte/generator-single-spa-svelte.js
+++ b/packages/generator-single-spa/src/svelte/generator-single-spa-svelte.js
@@ -20,7 +20,7 @@ module.exports = class SingleSpaSvelteGenerator extends Generator {
       type: String,
     });
   }
-  async createPackageJson() {
+  async getOptions() {
     if (!this.options.packageManager) {
       this.options.packageManager = (
         await this.prompt([
@@ -72,7 +72,8 @@ module.exports = class SingleSpaSvelteGenerator extends Generator {
         ])
       ).projectName;
     }
-
+  }
+  async createPackageJson() {
     const packageJsonTemplate = await fs.readFile(
       this.templatePath("package.json"),
       { encoding: "utf-8" }

--- a/packages/generator-single-spa/src/util-module/generator-single-spa-util-module.js
+++ b/packages/generator-single-spa/src/util-module/generator-single-spa-util-module.js
@@ -68,7 +68,7 @@ module.exports = class SingleSpaUtilModuleGenerator extends Generator {
     }
 
     while (!this.options.projectName) {
-      let { projectName } = await await this.prompt([
+      let { projectName } = await this.prompt([
         {
           type: "input",
           name: "projectName",

--- a/packages/generator-single-spa/src/util-module/generator-single-spa-util-module.js
+++ b/packages/generator-single-spa/src/util-module/generator-single-spa-util-module.js
@@ -50,16 +50,18 @@ module.exports = class SingleSpaUtilModuleGenerator extends Generator {
       ).typescript;
     }
 
-    if (!this.options.orgName) {
-      this.options.orgName = (
-        await this.prompt([
-          {
-            type: "input",
-            name: "orgName",
-            message: "Organization name (use lowercase and dashes)",
-          },
-        ])
-      ).orgName;
+    while (!this.options.orgName) {
+      let { orgName } = await this.prompt([
+        {
+          type: "input",
+          name: "orgName",
+          message: "Organization name (use lowercase and dashes)",
+        },
+      ]);
+
+      orgName = orgName && orgName.trim();
+      if (!orgName) console.log(chalk.red("orgName must be provided!"));
+      this.options.orgName = orgName;
     }
 
     if (!this.options.projectName) {

--- a/packages/generator-single-spa/src/util-module/generator-single-spa-util-module.js
+++ b/packages/generator-single-spa/src/util-module/generator-single-spa-util-module.js
@@ -2,6 +2,7 @@ const Generator = require("yeoman-generator");
 const ejs = require("ejs");
 const fs = require("fs").promises;
 const chalk = require("chalk");
+const isValidName = require("../naming");
 
 module.exports = class SingleSpaUtilModuleGenerator extends Generator {
   constructor(args, opts) {
@@ -61,6 +62,8 @@ module.exports = class SingleSpaUtilModuleGenerator extends Generator {
 
       orgName = orgName && orgName.trim();
       if (!orgName) console.log(chalk.red("orgName must be provided!"));
+      if (!isValidName(orgName))
+        console.log(chalk.red("orgName must use lowercase and dashes!"));
       this.options.orgName = orgName;
     }
 
@@ -75,6 +78,8 @@ module.exports = class SingleSpaUtilModuleGenerator extends Generator {
 
       projectName = projectName && projectName.trim();
       if (!projectName) console.log(chalk.red("projectName must be provided!"));
+      if (!isValidName(projectName))
+        console.log(chalk.red("projectName must use lowercase and dashes!"));
       this.options.projectName = projectName;
     }
 

--- a/packages/generator-single-spa/src/util-module/generator-single-spa-util-module.js
+++ b/packages/generator-single-spa/src/util-module/generator-single-spa-util-module.js
@@ -64,16 +64,18 @@ module.exports = class SingleSpaUtilModuleGenerator extends Generator {
       this.options.orgName = orgName;
     }
 
-    if (!this.options.projectName) {
-      this.options.projectName = (
-        await this.prompt([
-          {
-            type: "input",
-            name: "projectName",
-            message: "Project name (use lowercase and dashes)",
-          },
-        ])
-      ).projectName;
+    while (!this.options.projectName) {
+      let { projectName } = await await this.prompt([
+        {
+          type: "input",
+          name: "projectName",
+          message: "Project name (use lowercase and dashes)",
+        },
+      ]);
+
+      projectName = projectName && projectName.trim();
+      if (!projectName) console.log(chalk.red("projectName must be provided!"));
+      this.options.projectName = projectName;
     }
 
     this.options.framework = "none";

--- a/packages/generator-single-spa/src/util-module/generator-single-spa-util-module.js
+++ b/packages/generator-single-spa/src/util-module/generator-single-spa-util-module.js
@@ -23,7 +23,7 @@ module.exports = class SingleSpaUtilModuleGenerator extends Generator {
       type: String,
     });
   }
-  async createPackageJson() {
+  async getOptions() {
     if (!this.options.packageManager) {
       this.options.packageManager = (
         await this.prompt([
@@ -50,6 +50,33 @@ module.exports = class SingleSpaUtilModuleGenerator extends Generator {
       ).typescript;
     }
 
+    if (!this.options.orgName) {
+      this.options.orgName = (
+        await this.prompt([
+          {
+            type: "input",
+            name: "orgName",
+            message: "Organization name (use lowercase and dashes)",
+          },
+        ])
+      ).orgName;
+    }
+
+    if (!this.options.projectName) {
+      this.options.projectName = (
+        await this.prompt([
+          {
+            type: "input",
+            name: "projectName",
+            message: "Project name (use lowercase and dashes)",
+          },
+        ])
+      ).projectName;
+    }
+
+    this.options.framework = "none";
+  }
+  async createPackageJson() {
     const packageJsonTemplate = await fs.readFile(
       this.templatePath("package.json"),
       { encoding: "utf-8" }
@@ -82,32 +109,6 @@ module.exports = class SingleSpaUtilModuleGenerator extends Generator {
     }
   }
   async copyOtherFiles() {
-    if (!this.options.orgName) {
-      this.options.orgName = (
-        await this.prompt([
-          {
-            type: "input",
-            name: "orgName",
-            message: "Organization name (use lowercase and dashes)",
-          },
-        ])
-      ).orgName;
-    }
-
-    if (!this.options.projectName) {
-      this.options.projectName = (
-        await this.prompt([
-          {
-            type: "input",
-            name: "projectName",
-            message: "Project name (use lowercase and dashes)",
-          },
-        ])
-      ).projectName;
-    }
-
-    this.options.framework = "none";
-
     const srcFileExtension = this.options.typescript ? "ts" : "js";
 
     this.fs.copyTpl(

--- a/packages/generator-single-spa/test/basic.test.js
+++ b/packages/generator-single-spa/test/basic.test.js
@@ -18,6 +18,8 @@ describe("generator-single-spa", () => {
       })
       .withPrompts({
         packageManager: "yarn",
+        orgName: "org",
+        projectName: "basic-test",
       });
 
     return runContext.then((dir) => {

--- a/packages/generator-single-spa/test/naming.test.js
+++ b/packages/generator-single-spa/test/naming.test.js
@@ -1,0 +1,12 @@
+const isValidName = require("../src/naming");
+
+describe("generator-single-spa naming convention", () => {
+  it("enforces naming convention correctly", () => {
+    expect(isValidName("org")).toEqual(true);
+    expect(isValidName("org-name")).toEqual(true);
+
+    expect(isValidName("@org")).toEqual(false);
+    expect(isValidName("orgName")).toEqual(false);
+    expect(isValidName("1234")).toEqual(false);
+  });
+});

--- a/packages/generator-single-spa/test/react.test.js
+++ b/packages/generator-single-spa/test/react.test.js
@@ -5,22 +5,27 @@ const assert = require("yeoman-assert");
 
 describe("generator-single-spa-react", () => {
   let runContext;
+  const generateRunContext = (prompts) =>
+    helpers
+      .run(generator)
+      .withOptions({
+        framework: "react",
+      })
+      .withPrompts({
+        packageManager: "npm",
+        orgName: "org",
+        projectName: "react-project",
+        ...prompts,
+      });
 
   afterEach(() => {
     runContext.cleanTestDirectory();
   });
 
   it("handles yarn option properly", () => {
-    runContext = helpers
-      .run(generator)
-      .withOptions({
-        framework: "react",
-      })
-      .withPrompts({
-        packageManager: "yarn",
-        orgName: "org",
-        projectName: "react-project",
-      });
+    runContext = generateRunContext({
+      packageManager: "yarn",
+    });
 
     return runContext.then((dir) => {
       assert.file(path.join(dir, "package.json"));
@@ -36,16 +41,7 @@ describe("generator-single-spa-react", () => {
   });
 
   it("handles npm option properly", () => {
-    runContext = helpers
-      .run(generator)
-      .withOptions({
-        framework: "react",
-      })
-      .withPrompts({
-        packageManager: "npm",
-        orgName: "org",
-        projectName: "react-project",
-      });
+    runContext = generateRunContext();
 
     return runContext.then((dir) => {
       assert.file(path.join(dir, "package.json"));
@@ -61,16 +57,7 @@ describe("generator-single-spa-react", () => {
   });
 
   it("copies the correct files over", () => {
-    runContext = helpers
-      .run(generator)
-      .withOptions({
-        framework: "react",
-      })
-      .withPrompts({
-        packageManager: "npm",
-        orgName: "org",
-        projectName: "react-project",
-      });
+    runContext = generateRunContext();
 
     return runContext.then((dir) => {
       assert.file(path.join(dir, "jest.config.js"));

--- a/packages/generator-single-spa/test/react.test.js
+++ b/packages/generator-single-spa/test/react.test.js
@@ -18,6 +18,8 @@ describe("generator-single-spa-react", () => {
       })
       .withPrompts({
         packageManager: "yarn",
+        orgName: "org",
+        projectName: "react-project",
       });
 
     return runContext.then((dir) => {
@@ -41,6 +43,8 @@ describe("generator-single-spa-react", () => {
       })
       .withPrompts({
         packageManager: "npm",
+        orgName: "org",
+        projectName: "react-project",
       });
 
     return runContext.then((dir) => {
@@ -64,6 +68,8 @@ describe("generator-single-spa-react", () => {
       })
       .withPrompts({
         packageManager: "npm",
+        orgName: "org",
+        projectName: "react-project",
       });
 
     return runContext.then((dir) => {

--- a/packages/generator-single-spa/test/svelte.test.js
+++ b/packages/generator-single-spa/test/svelte.test.js
@@ -5,22 +5,25 @@ const assert = require("yeoman-assert");
 
 describe("generator-single-spa-svelte", () => {
   let runContext;
+  const generateRunContext = (prompts) =>
+    helpers
+      .run(generator)
+      .withOptions({
+        framework: "svelte",
+      })
+      .withPrompts({
+        packageManager: "npm",
+        orgName: "org",
+        projectName: "svelte-project",
+        ...prompts,
+      });
 
   afterEach(() => {
     runContext.cleanTestDirectory();
   });
 
   it("handles yarn option properly", () => {
-    runContext = helpers
-      .run(generator)
-      .withOptions({
-        framework: "svelte",
-      })
-      .withPrompts({
-        packageManager: "yarn",
-        orgName: "org",
-        projectName: "svelte-project",
-      });
+    runContext = generateRunContext({ packageManager: "yarn" });
 
     return runContext.then((dir) => {
       assert.file(path.join(dir, "package.json"));
@@ -28,16 +31,7 @@ describe("generator-single-spa-svelte", () => {
   });
 
   it("handles npm option properly", () => {
-    runContext = helpers
-      .run(generator)
-      .withOptions({
-        framework: "react",
-      })
-      .withPrompts({
-        packageManager: "npm",
-        orgName: "org",
-        projectName: "svelte-project",
-      });
+    runContext = generateRunContext();
 
     return runContext.then((dir) => {
       assert.file(path.join(dir, "package.json"));
@@ -45,16 +39,7 @@ describe("generator-single-spa-svelte", () => {
   });
 
   it("copies the correct files over", () => {
-    runContext = helpers
-      .run(generator)
-      .withOptions({
-        framework: "svelte",
-      })
-      .withPrompts({
-        packageManager: "npm",
-        orgName: "org",
-        projectName: "svelte-project",
-      });
+    runContext = generateRunContext();
 
     return runContext.then((dir) => {
       assert.file(path.join(dir, "rollup.config.js"));

--- a/packages/generator-single-spa/test/svelte.test.js
+++ b/packages/generator-single-spa/test/svelte.test.js
@@ -18,6 +18,8 @@ describe("generator-single-spa-svelte", () => {
       })
       .withPrompts({
         packageManager: "yarn",
+        orgName: "org",
+        projectName: "svelte-project",
       });
 
     return runContext.then((dir) => {
@@ -33,6 +35,8 @@ describe("generator-single-spa-svelte", () => {
       })
       .withPrompts({
         packageManager: "npm",
+        orgName: "org",
+        projectName: "svelte-project",
       });
 
     return runContext.then((dir) => {
@@ -48,6 +52,8 @@ describe("generator-single-spa-svelte", () => {
       })
       .withPrompts({
         packageManager: "npm",
+        orgName: "org",
+        projectName: "svelte-project",
       });
 
     return runContext.then((dir) => {

--- a/packages/generator-single-spa/test/util-module.test.js
+++ b/packages/generator-single-spa/test/util-module.test.js
@@ -6,22 +6,25 @@ const assert = require("yeoman-assert");
 
 describe("generator-single-spa-util-module", () => {
   let runContext;
+  const generateRunContext = (prompts) =>
+    helpers
+      .run(generator)
+      .withOptions({
+        moduleType: "util-module",
+      })
+      .withPrompts({
+        packageManager: "npm",
+        orgName: "org",
+        projectName: "util-module-project",
+        ...prompts,
+      });
 
   afterEach(() => {
     runContext.cleanTestDirectory();
   });
 
   it("handles yarn option properly", () => {
-    runContext = helpers
-      .run(generator)
-      .withOptions({
-        moduleType: "util-module",
-      })
-      .withPrompts({
-        packageManager: "yarn",
-        orgName: "org",
-        projectName: "util-module-project",
-      });
+    runContext = generateRunContext({ packageManager: "yarn" });
 
     return runContext.then((dir) => {
       assert.file(path.join(dir, "package.json"));
@@ -37,16 +40,7 @@ describe("generator-single-spa-util-module", () => {
   });
 
   it("handles npm option properly", () => {
-    runContext = helpers
-      .run(generator)
-      .withOptions({
-        moduleType: "util-module",
-      })
-      .withPrompts({
-        packageManager: "npm",
-        orgName: "org",
-        projectName: "util-module-project",
-      });
+    runContext = generateRunContext();
 
     return runContext.then((dir) => {
       assert.file(path.join(dir, "package.json"));
@@ -62,16 +56,7 @@ describe("generator-single-spa-util-module", () => {
   });
 
   it("copies the correct files over", () => {
-    runContext = helpers
-      .run(generator)
-      .withOptions({
-        framework: "react",
-      })
-      .withPrompts({
-        packageManager: "npm",
-        orgName: "org",
-        projectName: "util-module-project",
-      });
+    runContext = generateRunContext();
 
     return runContext.then((dir) => {
       assert.file(path.join(dir, "jest.config.js"));

--- a/packages/generator-single-spa/test/util-module.test.js
+++ b/packages/generator-single-spa/test/util-module.test.js
@@ -19,6 +19,8 @@ describe("generator-single-spa-util-module", () => {
       })
       .withPrompts({
         packageManager: "yarn",
+        orgName: "org",
+        projectName: "util-module-project",
       });
 
     return runContext.then((dir) => {
@@ -42,6 +44,8 @@ describe("generator-single-spa-util-module", () => {
       })
       .withPrompts({
         packageManager: "npm",
+        orgName: "org",
+        projectName: "util-module-project",
       });
 
     return runContext.then((dir) => {
@@ -65,6 +69,8 @@ describe("generator-single-spa-util-module", () => {
       })
       .withPrompts({
         packageManager: "npm",
+        orgName: "org",
+        projectName: "util-module-project",
       });
 
     return runContext.then((dir) => {


### PR DESCRIPTION
If no orgName or projectName is provided or spaces are included, then the output has some weird references and filenames. These changes guard against providing empty and invalid input, validating that the names match the "use lowercase and dashes" instructions.

These changes also reorganize the locations of where options are being prompted for so that they are in the same function block.