### PR TITLE
Check and notify user if a newer version is available

### DIFF
--- a/packages/generator-single-spa/package.json
+++ b/packages/generator-single-spa/package.json
@@ -8,7 +8,7 @@
     "src"
   ],
   "scripts": {
-    "test": "jest --testPathIgnorePatterns templates"
+    "test": "jest"
   },
   "version": "1.11.0",
   "main": "src/generator-single-spa.js",
@@ -22,5 +22,10 @@
     "jest": "^24.9.0",
     "yeoman-assert": "^3.1.1",
     "yeoman-test": "^2.0.0"
+  },
+  "jest": {
+    "testPathIgnorePatterns": [
+      "templates"
+    ]
   }
 }

--- a/packages/generator-single-spa/src/generator-single-spa.js
+++ b/packages/generator-single-spa/src/generator-single-spa.js
@@ -6,8 +6,8 @@ const SingleSpaVueGenerator = require("./vue/generator-single-spa-vue");
 const SingleSpaAngularGenerator = require("./angular/generator-single-spa-angular");
 const SingleSpaUtilModuleGenerator = require("./util-module/generator-single-spa-util-module");
 const SingleSpaSvelteGenerator = require("./svelte/generator-single-spa-svelte");
+const versionUpdateCheck = require("./version-update-check");
 const { version } = require("../package.json");
-const chalk = require("chalk");
 
 module.exports = class SingleSpaGenerator extends Generator {
   constructor(args, opts) {
@@ -39,28 +39,8 @@ module.exports = class SingleSpaGenerator extends Generator {
       ["view", "create-single-spa@latest", "version"],
       { stdio: "pipe" }
     );
-    const latestVersion = stdout.toString("utf8").trim();
-    const [latestMajor, latestMinor, latestPatch] = latestVersion.split(".");
-    const [currentMajor, currentMinor, currentPatch] = version.split(".");
-    const majorUpdate = currentMajor < latestMajor;
-    const minorUpdate = currentMinor < latestMinor;
-    const patchUpdate = currentPatch < latestPatch;
 
-    if (majorUpdate | minorUpdate | patchUpdate) {
-      let msg = `${version} → ${latestVersion}`;
-      if (majorUpdate) {
-        msg = chalk.red(msg);
-      } else if (minorUpdate) {
-        msg = chalk.yellow(msg);
-      } else {
-        msg = chalk.green(msg);
-      }
-      console.log(
-        chalk.underline(
-          `\nA newer version of create-single-spa is available: ${msg}\n`
-        )
-      );
-    }
+    versionUpdateCheck(version, stdout.toString("utf8").trim());
   }
   async chooseDestinationDir() {
     if (!this.options.dir) {

--- a/packages/generator-single-spa/src/generator-single-spa.js
+++ b/packages/generator-single-spa/src/generator-single-spa.js
@@ -6,6 +6,8 @@ const SingleSpaVueGenerator = require("./vue/generator-single-spa-vue");
 const SingleSpaAngularGenerator = require("./angular/generator-single-spa-angular");
 const SingleSpaUtilModuleGenerator = require("./util-module/generator-single-spa-util-module");
 const SingleSpaSvelteGenerator = require("./svelte/generator-single-spa-svelte");
+const { version } = require("../package.json");
+const chalk = require("chalk");
 
 module.exports = class SingleSpaGenerator extends Generator {
   constructor(args, opts) {
@@ -30,6 +32,35 @@ module.exports = class SingleSpaGenerator extends Generator {
     Object.keys(this.options).forEach((optionKey) => {
       if (this.options[optionKey] === "false") this.options[optionKey] = false;
     });
+  }
+  initializing() {
+    const { stdout } = this.spawnCommandSync(
+      "npm",
+      ["view", "create-single-spa@latest", "version"],
+      { stdio: "pipe" }
+    );
+    const latestVersion = stdout.toString("utf8").trim();
+    const [latestMajor, latestMinor, latestPatch] = latestVersion.split(".");
+    const [currentMajor, currentMinor, currentPatch] = version.split(".");
+    const majorUpdate = currentMajor < latestMajor;
+    const minorUpdate = currentMinor < latestMinor;
+    const patchUpdate = currentPatch < latestPatch;
+
+    if (majorUpdate | minorUpdate | patchUpdate) {
+      let msg = `${version} → ${latestVersion}`;
+      if (majorUpdate) {
+        msg = chalk.red(msg);
+      } else if (minorUpdate) {
+        msg = chalk.yellow(msg);
+      } else {
+        msg = chalk.green(msg);
+      }
+      console.log(
+        chalk.underline(
+          `\nA newer version of create-single-spa is available: ${msg}\n`
+        )
+      );
+    }
   }
   async chooseDestinationDir() {
     if (!this.options.dir) {

--- a/packages/generator-single-spa/src/version-update-check.js
+++ b/packages/generator-single-spa/src/version-update-check.js
@@ -1,0 +1,35 @@
+const chalk = require("chalk");
+
+module.exports = function versionUpdateCheck(currentVersion, latestVersion) {
+  try {
+    const [latestMajor, latestMinor, latestPatch] = latestVersion.split(".");
+    const [currentMajor, currentMinor, currentPatch] = currentVersion.split(
+      "."
+    );
+    const majorUpdate = currentMajor < latestMajor;
+    const minorUpdate = currentMinor < latestMinor;
+    const patchUpdate = currentPatch < latestPatch;
+
+    if (majorUpdate | minorUpdate | patchUpdate) {
+      let updateType;
+      let msg = `${currentVersion} → ${latestVersion}`;
+      if (majorUpdate) {
+        updateType = chalk.red("major update");
+        msg = chalk.red(msg);
+      } else if (minorUpdate) {
+        updateType = chalk.yellow("minor update");
+        msg = chalk.yellow(msg);
+      } else {
+        updateType = chalk.green("patch update");
+        msg = chalk.green(msg);
+      }
+      console.log(
+        chalk.underline(
+          `\nA ${updateType} of create-single-spa is available: ${msg}\n`
+        )
+      );
+    }
+  } catch (e) {
+    // Fail silently
+  }
+};

--- a/packages/generator-single-spa/test/version-update-check.test.js
+++ b/packages/generator-single-spa/test/version-update-check.test.js
@@ -1,0 +1,49 @@
+const checkForVersionUpdate = require("../src/version-update-check");
+
+describe("Checks for version update", () => {
+  const log = console.log;
+  const currentVersion = "1.1.1";
+
+  beforeEach(() => {
+    console.log = jest.fn();
+  });
+
+  afterAll(() => {
+    console.log = log;
+  });
+
+  test("no update", () => {
+    checkForVersionUpdate(currentVersion, currentVersion);
+    expect(console.log).not.toHaveBeenCalled();
+  });
+
+  test("patch update", () => {
+    const patchVersionUpdate = "1.1.2";
+    checkForVersionUpdate(currentVersion, patchVersionUpdate);
+    expect(console.log).toHaveBeenCalled();
+    const message = console.log.mock.calls[0][0];
+    expect(message).toEqual(expect.stringContaining("patch update"));
+    expect(message).toEqual(expect.stringContaining(currentVersion));
+    expect(message).toEqual(expect.stringContaining(patchVersionUpdate));
+  });
+
+  test("minor update", () => {
+    const minorVersionUpdate = "1.2.1";
+    checkForVersionUpdate(currentVersion, minorVersionUpdate);
+    expect(console.log).toHaveBeenCalled();
+    const message = console.log.mock.calls[0][0];
+    expect(message).toEqual(expect.stringContaining("minor update"));
+    expect(message).toEqual(expect.stringContaining(currentVersion));
+    expect(message).toEqual(expect.stringContaining(minorVersionUpdate));
+  });
+
+  test("major update", () => {
+    const majorVersionUpdate = "2.1.1";
+    checkForVersionUpdate(currentVersion, majorVersionUpdate);
+    expect(console.log).toHaveBeenCalled();
+    const message = console.log.mock.calls[0][0];
+    expect(message).toEqual(expect.stringContaining("major update"));
+    expect(message).toEqual(expect.stringContaining(currentVersion));
+    expect(message).toEqual(expect.stringContaining(majorVersionUpdate));
+  });
+});


### PR DESCRIPTION
Resolves #142 

Below is a screenshot of what the terminal message with colors when an outdated version is detected.

![Screen Shot 2020-07-07 at 4 37 16 PM](https://user-images.githubusercontent.com/4202993/86851962-1e469100-c071-11ea-9c38-8d0fdf2b18c8.png)

I decided last minute to add the underline styling (to help distinguish from the rest of the prompt) after I took the above screenshot.

![Screen Shot 2020-07-07 at 4 45 44 PM](https://user-images.githubusercontent.com/4202993/86852076-5352e380-c071-11ea-827e-051da9dd1b4f.png)

Feedback: 
- Should there be some sort of flag or config we can add to silence this message? 
- ~~I can't find a good way to test this... should I maybe move it into an external module to simplify testing?~~ I did move these into an external module with some corresponding tests.