### PR TITLE
Adding .DS_Store files to gitignores

### DIFF
--- a/packages/generator-single-spa/src/common-templates/gitignore
+++ b/packages/generator-single-spa/src/common-templates/gitignore
@@ -69,3 +69,4 @@ dist
 *.njsproj
 *.sln
 *.sw?
+.DS_Store

--- a/packages/single-spa-welcome/.gitignore
+++ b/packages/single-spa-welcome/.gitignore
@@ -69,3 +69,4 @@ dist
 *.njsproj
 *.sln
 *.sw?
+.DS_Store


### PR DESCRIPTION
Noticed this while working with a client - .DS_Store aren't gitignored in generated projects.