### PR TITLE
Fixing "format" script on Windows.

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "test:e2e": "jest",
     "lint": "lerna run lint",
     "publish-all": "lerna publish",
-    "format": "prettier './**/*' --write"
+    "format": "prettier \"./**/*\" --write"
   },
   "husky": {
     "hooks": {

--- a/packages/generator-single-spa/src/react/templates/package.json
+++ b/packages/generator-single-spa/src/react/templates/package.json
@@ -4,7 +4,7 @@
     "build": "webpack --mode=production",
     "analyze": "webpack --mode=production --env.analyze=true",
     "lint": "eslint src --ext js<% if (typescript) { %>,ts,tsx<% } %>",
-    "format": "prettier --write './**'",
+    "format": "prettier --write \"./**\"",
     "test": "cross-env BABEL_ENV=test jest",
     "watch-tests": "cross-env BABEL_ENV=test jest --watch",
     "coverage": "cross-env BABEL_ENV=test jest --coverage"

--- a/packages/generator-single-spa/src/root-config/templates/package.json
+++ b/packages/generator-single-spa/src/root-config/templates/package.json
@@ -3,7 +3,7 @@
     "start": "webpack-dev-server --mode=development --port 9000 --env.isLocal=true",
     "lint": "eslint src --ext js<% if (typescript) { %>,ts,tsx<% } %>",
     "test": "cross-env BABEL_ENV=test jest --passWithNoTests",
-    "format": "prettier --write './**'",
+    "format": "prettier --write \"./**\"",
     "build": "webpack --mode=production"
   },
   "husky": {

--- a/packages/single-spa-welcome/package.json
+++ b/packages/single-spa-welcome/package.json
@@ -21,7 +21,7 @@
     "build": "webpack --mode=production",
     "analyze": "webpack --mode=production --env.analyze=true",
     "lint": "eslint src --ext js",
-    "format": "prettier --write './**'",
+    "format": "prettier --write \"./**\"",
     "test": "cross-env BABEL_ENV=test jest",
     "watch-tests": "cross-env BABEL_ENV=test jest --watch",
     "coverage": "cross-env BABEL_ENV=test jest --coverage",


### PR DESCRIPTION
On Windows, the `npm run format` command doesn't work.

Before fix:

![image](https://user-images.githubusercontent.com/5524384/87463388-88f65000-c5ce-11ea-9675-fa4e9b80e708.png)

After fix:

![image](https://user-images.githubusercontent.com/5524384/87463296-6a905480-c5ce-11ea-8b5d-0c26e9e4d937.png)
