### PR TITLE
Fix/vue app orgname

### DIFF
--- a/packages/generator-single-spa/src/vue/generator-single-spa-vue.js
+++ b/packages/generator-single-spa/src/vue/generator-single-spa-vue.js
@@ -4,6 +4,7 @@ const util = require("util");
 const commandExists = util.promisify(require("command-exists"));
 const chalk = require("chalk");
 const path = require("path");
+const isValidName = require("../naming");
 
 module.exports = class SingleSpaVueGenerator extends Generator {
   constructor(args, opts) {
@@ -46,12 +47,17 @@ module.exports = class SingleSpaVueGenerator extends Generator {
       command += ".cmd";
     }
 
-    this.cwd = this.options.dir || ".";
+    // Derrive projectName value
+    const { dir, name } = path.parse(this.options.dir || ".");
+    if (!name) throw new Error("projectName must be provided!");
+    if (!isValidName(name))
+      throw new Error("projectName must use lowercase and dashes!");
 
     const { status, signal } = spawnSync(
       command,
-      args.concat(["create", this.cwd, "--skipGetStarted"]),
+      args.concat(["create", name, "--skipGetStarted"]),
       {
+        cwd: dir,
         stdio: "inherit",
       }
     );

--- a/packages/generator-single-spa/src/vue/generator-single-spa-vue.js
+++ b/packages/generator-single-spa/src/vue/generator-single-spa-vue.js
@@ -48,7 +48,7 @@ module.exports = class SingleSpaVueGenerator extends Generator {
       command += ".cmd";
     }
 
-    // Derrive projectName value
+    // Derive projectName value
     const { dir, name } = path.parse(this.options.dir || ".");
     if (!name) throw new Error("projectName must be provided!");
     if (!isValidName(name))

--- a/packages/generator-single-spa/src/vue/generator-single-spa-vue.js
+++ b/packages/generator-single-spa/src/vue/generator-single-spa-vue.js
@@ -69,30 +69,31 @@ module.exports = class SingleSpaVueGenerator extends Generator {
       process.exit(status);
     }
 
-    const projectPath = path.resolve(dir, name);
-    const pkgJsonPath = path.resolve(projectPath, "package.json");
+    const pkgJsonPath = path.resolve(this.options.dir, "package.json");
     const pkgJson = JSON.parse(fs.readFileSync(pkgJsonPath));
-    pkgJson.name = this.projectName = `@${this.options.orgName}/${name}`;
+    this.projectName = pkgJson.name = `@${this.options.orgName}/${name}`;
     fs.writeFileSync(pkgJsonPath, JSON.stringify(pkgJson, null, 2));
 
     // We purposely do not attempt to install in one command using presets to avoid being too restrictive with application configuration
     spawnSync(command, args.concat(["add", "single-spa"]), {
       stdio: "inherit",
-      cwd: projectPath,
+      cwd: this.options.dir,
       env: Object.assign({}, process.env, {
         VUE_CLI_SKIP_DIRTY_GIT_PROMPT: true,
       }),
     });
   }
   async finished() {
-    const usedYarn = this.fs.exists(path.resolve(this.cwd, "yarn.lock"));
+    const usedYarn = this.fs.exists(
+      path.resolve(this.options.dir, "yarn.lock")
+    );
     console.log(
       chalk.bgWhite.black(
         `Project setup complete!
 Steps to test your Vue single-spa application:
 1. Run '${usedYarn ? "yarn" : "npm run"} serve'
 2. Go to http://single-spa-playground.org/playground/instant-test?name=${
-          this.options.dir
+          this.projectName
         }&url=%2F%2Flocalhost%3A8080%2Fjs%2Fapp.js&framework=vue to see it working!`
       )
     );

--- a/packages/generator-single-spa/src/vue/generator-single-spa-vue.js
+++ b/packages/generator-single-spa/src/vue/generator-single-spa-vue.js
@@ -6,6 +6,30 @@ const chalk = require("chalk");
 const path = require("path");
 
 module.exports = class SingleSpaVueGenerator extends Generator {
+  constructor(args, opts) {
+    super(args, opts);
+
+    this.option("orgName", {
+      type: String,
+    });
+  }
+  async getOptions() {
+    while (!this.options.orgName) {
+      let { orgName } = await this.prompt([
+        {
+          type: "input",
+          name: "orgName",
+          message: "Organization name (use lowercase and dashes)",
+        },
+      ]);
+
+      orgName = orgName && orgName.trim();
+      if (!orgName) console.log(chalk.red("orgName must be provided!"));
+      if (!isValidName(orgName))
+        console.log(chalk.red("orgName must use lowercase and dashes!"));
+      this.options.orgName = orgName;
+    }
+  }
   async runVueCli() {
     const globalInstallation = await commandExists("vue");
 


### PR DESCRIPTION
Resolves #148

The approach I took makes the following changes: 
- I made the `dir` a little more flexible and resilient by allowing it to be a folder path (eg. `create-single-spa ../my-new-app`)
- The generator now prompts for and validates the `orgName`
- `projectName` is derived from the `dir` (eg. from the above command the projectName would be `my-new-app` which is used when calling `vue create`)
    - `projectName` is now also validated like all the other options
- After the project is created, the package.json is modified to include the orgName (eg. `@org/my-new-app`)
- Then `vue add single-spa` is called, and the correct value is used by the plugin to include the orgName throughout

There are no tests for the Vue functionality because we need to invoke the \@vue/cli, and I'm not sure how to approach validating this beyond manual testing. Also, I'd like for someone to run this on a Windows machine in case there are any problems with the path.resolve calls. 