### PR TITLE
Add layout issues link

### DIFF
--- a/packages/generator-single-spa/src/root-config/generator-root-config.js
+++ b/packages/generator-single-spa/src/root-config/generator-root-config.js
@@ -193,6 +193,12 @@ module.exports = class SingleSpaRootConfigGenerator extends Generator {
         chalk.bgWhite.black(`Project setup complete!
 Run '${this.options.packageManager} start' to boot up your single-spa root config`)
       );
+
+      if (this.options.layout) {
+        console.log(
+          `\nPlease report single-spa-layout issues and bugs on GitHub https://github.com/single-spa/single-spa-layout/issues/new`
+        );
+      }
     });
   }
 };

--- a/packages/generator-single-spa/src/root-config/generator-root-config.js
+++ b/packages/generator-single-spa/src/root-config/generator-root-config.js
@@ -170,18 +170,22 @@ module.exports = class SingleSpaRootConfigGenerator extends Generator {
       this.options,
       { delimiter: "?" }
     );
-  }
-  install() {
-    if (this.options.packageManager === "npm")
-      this.npmInstall(["single-spa-layout@beta"]);
-    if (this.options.packageManager === "yarn")
-      this.yarnInstall(["single-spa-layout@beta"]);
 
-    this.installDependencies({
-      npm: this.options.packageManager === "npm",
-      yarn: this.options.packageManager === "yarn",
-      bower: false,
-    });
+    if (this.options.layout) {
+      const { stdout } = this.spawnCommandSync(
+        "npm",
+        ["view", "single-spa-layout@beta", "version"],
+        { stdio: "pipe" }
+      );
+
+      const singleSpaLayoutBetaVersion = stdout.toString("utf8").trim();
+
+      this.fs.extendJSON(this.destinationPath("package.json"), {
+        dependencies: {
+          "single-spa-layout": singleSpaLayoutBetaVersion,
+        },
+      });
+    }
   }
   finished() {
     this.on(`${this.options.packageManager}Install:end`, () => {


### PR DESCRIPTION
This change adds messaging after adding single-spa-layout to direct people to GitHub to report issues. While doing this, I noticed that single-spa-layout was being installed even if not using it and causing an extra `install` step, so I've fixed that by extending the package.json instead of calling `install`. 