### PR TITLE
Fix: Vue app generation silently fails

### DIFF
--- a/packages/generator-single-spa/src/vue/generator-single-spa-vue.js
+++ b/packages/generator-single-spa/src/vue/generator-single-spa-vue.js
@@ -39,7 +39,7 @@ module.exports = class SingleSpaVueGenerator extends Generator {
       }
     }
 
-    let { dir, name } = path.parse(this.options.dir);
+    let { dir, name } = path.parse(path.resolve(this.options.dir));
 
     if (!isValidName(name)) {
       while (!this.options.projectName) {


### PR DESCRIPTION
Resolves #173 . Vue app generation silently fails because `dir` is an empty string if a non-relative dir/path is provided. This change resolves dir before parsing, which should guarantee that dir is not an empty string but rather a full path.