### PR TITLE
Remove validateSingleSpaDependency check

### DIFF
--- a/packages/generator-single-spa/src/angular/generator-single-spa-angular.js
+++ b/packages/generator-single-spa/src/angular/generator-single-spa-angular.js
@@ -90,30 +90,6 @@ module.exports = class SingleSpaAngularGenerator extends Generator {
     }
   }
 
-  // Including single-spa as a dependency has not been fully resolved.
-  // It is now included in the Angular schematic https://github.com/single-spa/single-spa-angular/pull/193
-  // but that has only been released as an alpha version https://github.com/single-spa/single-spa-angular/releases/tag/v4.1.0-alpha.0
-  async validateSingleSpaDependency() {
-    const { dependencies } = await this.fs.readJSON(`${this.cwd}/package.json`);
-    if (dependencies && !dependencies["single-spa"]) {
-      const install = (cmd, opts) =>
-        spawnSync(cmd, opts, {
-          stdio: "inherit",
-          cwd: this.cwd,
-        });
-      switch (this.options.packageManager) {
-        case "npm":
-          install("npm", ["install", "single-spa"]);
-          break;
-        case "yarn":
-          install("yarn", ["add", "single-spa"]);
-          break;
-        default:
-          break;
-      }
-    }
-  }
-
   async finished() {
     console.log(
       chalk.bgWhite.black(


### PR DESCRIPTION
Remove validateSingleSpaDependency since it is resolved as part of single-spa-angular install. This was useful before https://github.com/single-spa/single-spa-angular/pull/193 was merged but that code was released in [single-spa-angular@4.2.0](https://github.com/single-spa/single-spa-angular/releases/tag/v4.2.0). 
Removing this check should resolve #169 since it should no longer be necessary for create-single-spa to deal with this.