### PR TITLE
Feature: dynamically show instructions for single-spa-layout root-configs

### DIFF
--- a/packages/single-spa-welcome/src/welcome.css
+++ b/packages/single-spa-welcome/src/welcome.css
@@ -39,6 +39,13 @@ a:visited {
   color: #02a;
 }
 
+aside {
+  border-left: 3px solid #01f;
+  font-size: 0.9rem;
+  margin-top: 0.4em;
+  padding-left: 1ch;
+}
+
 .logo {
   display: block;
   margin-right: 1rem;

--- a/packages/single-spa-welcome/src/welcome.js
+++ b/packages/single-spa-welcome/src/welcome.js
@@ -7,7 +7,7 @@ export default function Root(props) {
     // While this won't work for SSR, the goal of this app is to help
     // beginners, which likely won't use SSR before running their
     // first root-config.
-    const templates = Array.prototype.slice.call(
+    const templates = Array.from(
       document.querySelectorAll("template")
     );
 

--- a/packages/single-spa-welcome/src/welcome.js
+++ b/packages/single-spa-welcome/src/welcome.js
@@ -1,7 +1,24 @@
-import React from "react";
+import React, { useState } from "react";
 import "./welcome.css";
 
 export default function Root(props) {
+  const [isUsingSingleSpaLayout] = useState(() => {
+    // Search the dom for a single-spa-router element
+    // While this won't work for SSR, the goal of this app is to help
+    // beginners, which likely won't use SSR before running their
+    // first root-config.
+    const templates = Array.prototype.slice.call(
+      document.querySelectorAll("template")
+    );
+
+    return templates.some((template) => {
+      const hasSingleSpaRouter = !!template.content.querySelector(
+        "single-spa-router"
+      );
+      return hasSingleSpaRouter;
+    });
+  });
+
   return (
     <section id="welcome">
       <div className="banner">
@@ -30,7 +47,7 @@ export default function Root(props) {
       <h3>1. Add shared dependencies</h3>
       <ul>
         <li>
-          Locate the importmap in <code>src/index.ejs</code>
+          Locate the import map in <code>src/index.ejs</code>
         </li>
         <li>
           <p>
@@ -46,18 +63,45 @@ export default function Root(props) {
       </ul>
       <h3>2. Create your next single-spa application</h3>
       <ul>
-        <li>Generate a single-spa application with create-single-spa</li>
         <li>
-          Update the importmap in <code>src/index.ejs</code>
+          Generate a single-spa application with create-single-spa and follow
+          the prompts until it is running locally
         </li>
         <li>
-          Open <code>src/root-config.js</code> and remove the code for
-          registering this application
+          Return to the root-config and update the import map in{" "}
+          <code>src/index.ejs</code> with your project's name
+          <aside>
+            It's recommended to use the application's package.json name field
+          </aside>
         </li>
-        <li>
-          Uncomment the <code>registerApplication</code> code and update it with
-          your new application's name
-        </li>
+        {isUsingSingleSpaLayout ? (
+          <>
+            <li>
+              Locate the{" "}
+              <code>
+                &lt;application
+                name="@single-spa/welcome"&gt;&lt;/application&gt;
+              </code>{" "}
+              element and remove it
+            </li>
+            <li>
+              Using the name of your new application, add your own{" "}
+              <code>&lt;application name=""&gt;&lt;/application&gt;</code>{" "}
+              element to the single-spa layout
+            </li>
+          </>
+        ) : (
+          <>
+            <li>
+              Open <code>src/root-config.js</code> and remove the code for
+              registering this application
+            </li>
+            <li>
+              Uncomment the <code>registerApplication</code> code and update it
+              with your new application's name
+            </li>
+          </>
+        )}
       </ul>
       <p>
         After this, you should no longer see this welcome page but should

--- a/packages/single-spa-welcome/src/welcome.js
+++ b/packages/single-spa-welcome/src/welcome.js
@@ -128,7 +128,11 @@ export default function Root(props) {
             Import Maps
           </a>
         </li>
-        <li>Single-spa ecosystem</li>
+        <li>
+          <a href="https://single-spa.js.org/docs/ecosystem/">
+            Single-spa ecosystem
+          </a>
+        </li>
       </ul>
       <h2 id="contribute">Contribute</h2>
       <ul>

--- a/packages/single-spa-welcome/src/welcome.js
+++ b/packages/single-spa-welcome/src/welcome.js
@@ -51,16 +51,24 @@ export default function Root(props) {
         </li>
         <li>
           <p>
-            Add an entry for modules that you would like to have shared across
-            your dependencies. For example, to share React, add this to your
-            importmap.
+            Add an entry for modules that will be shared across your
+            dependencies. For example, a React application generated with
+            create-single-spa will need to add React and ReactDOM to the import
+            map.
           </p>
           <pre>
-            <code>{`"react": "https://cdn.jsdelivr.net/npm/react@16.13.0/umd/react.production.min.js",
-"react-dom": "https://cdn.jsdelivr.net/npm/react-dom@16.13.0/umd/react-dom.production.min.js"`}</code>
+            <code>{`"react": "https://cdn.jsdelivr.net/npm/react@16.13.1/umd/react.production.min.js",
+"react-dom": "https://cdn.jsdelivr.net/npm/react-dom@16.13.1/umd/react-dom.production.min.js"`}</code>
           </pre>
         </li>
       </ul>
+      <p>
+        Refer to the corresponding{" "}
+        <a href="https://single-spa.js.org/docs/ecosystem/#help-for-frameworks">
+          single-spa framework helpers
+        </a>{" "}
+        for more specific information.
+      </p>
       <h3>2. Create your next single-spa application</h3>
       <ul>
         <li>

--- a/packages/single-spa-welcome/src/welcome.js
+++ b/packages/single-spa-welcome/src/welcome.js
@@ -2,7 +2,7 @@ import React, { useState } from "react";
 import "./welcome.css";
 
 export default function Root(props) {
-  const [isUsingSingleSpaLayout] = useState(() => {
+  const isUsingSingleSpaLayout = useState(() => {
     // Search the dom for a single-spa-router element
     // While this won't work for SSR, the goal of this app is to help
     // beginners, which likely won't use SSR before running their
@@ -17,7 +17,7 @@ export default function Root(props) {
       );
       return hasSingleSpaRouter;
     });
-  });
+  })[0];
 
   return (
     <section id="welcome">

--- a/packages/single-spa-welcome/src/welcome.js
+++ b/packages/single-spa-welcome/src/welcome.js
@@ -7,9 +7,7 @@ export default function Root(props) {
     // While this won't work for SSR, the goal of this app is to help
     // beginners, which likely won't use SSR before running their
     // first root-config.
-    const templates = Array.from(
-      document.querySelectorAll("template")
-    );
+    const templates = Array.from(document.querySelectorAll("template"));
 
     return templates.some((template) => {
       const hasSingleSpaRouter = !!template.content.querySelector(


### PR DESCRIPTION
In order to better support single-spa-layout and improve a beginner's experience, I'm adding a feature that detects if a page has single-spa-router and displaying different "next steps" based on that. 

I also made some minor changes to the content to explain that shared dependencies are required for a React application. 