### PR TITLE
add option to not have packages from same org as external

### DIFF
--- a/packages/webpack-config-single-spa/lib/webpack-config-single-spa.js
+++ b/packages/webpack-config-single-spa/lib/webpack-config-single-spa.js
@@ -20,6 +20,10 @@ function webpackConfigSingleSpa(opts) {
     );
   }
 
+  if (opts.orgPackagesAsExternal !== false) {
+    opts.orgPackagesAsExternal = true;
+  }
+
   let webpackConfigEnv = opts.webpackConfigEnv || {};
 
   return {
@@ -72,7 +76,9 @@ function webpackConfigSingleSpa(opts) {
       },
       disableHostCheck: true,
     },
-    externals: ["single-spa", new RegExp(`^@${opts.orgName}/`)],
+    externals: opts.orgPackagesAsExternal
+      ? ["single-spa", new RegExp(`^@${opts.orgName}/`)]
+      : ["single-spa"],
     plugins: [
       new CleanWebpackPlugin(),
       new BundleAnalyzerPlugin({


### PR DESCRIPTION
See https://github.com/single-spa/create-single-spa/issues/109

Added a setting so that packages from the same org are not marked as external.

Usage: 
```
  const defaultConfig = singleSpaDefaults({
    // The name of the organization this application is written for
    orgName: 'name-of-company',
    // Boolean flag if all packages that are the same as orgName should be external
    orgPackagesAsExternal: false // default: true
  })
```