### PR TITLE
Remove trim behavior in validateNaming

### DIFF
--- a/packages/generator-single-spa/src/validate-naming.js
+++ b/packages/generator-single-spa/src/validate-naming.js
@@ -2,7 +2,6 @@ const BEGIN_WITH_LETTER = /^[a-zA-Z]/;
 const ALLOWED_CHARACTERS = /^[a-zA-Z0-9\-]+$/;
 
 module.exports = function validateNaming(input) {
-  input = input && input.trim();
   if (!input) {
     return `Cannot be empty!`;
   } else if (!BEGIN_WITH_LETTER.test(input)) {

--- a/packages/generator-single-spa/test/validate-naming.test.js
+++ b/packages/generator-single-spa/test/validate-naming.test.js
@@ -22,12 +22,14 @@ describe("validate-naming", () => {
       expect(validateNaming("@org")).toEqual(invalidMsg);
       expect(validateNaming("1234")).toEqual(invalidMsg);
       expect(validateNaming("123-org")).toEqual(invalidMsg);
+      expect(validateNaming("  org")).toEqual(invalidMsg);
     });
     test("contains invalid characters", () => {
       const invalidMsg = expect.stringContaining("May only contain");
 
       expect(validateNaming("org_123")).toEqual(invalidMsg);
       expect(validateNaming("org@123")).toEqual(invalidMsg);
+      expect(validateNaming("org  ")).toEqual(invalidMsg);
     });
   });
 });


### PR DESCRIPTION
Resolves #195 by removing the string trimming that happens inside of `validateNaming`, which transforms the input for the validation but does not retain that new value. By removing it, space characters will cause a validation error for `orgName` and `projectName`. In the case of the Vue generator, `dir` with spaces will work but then it will prompt for a `projectName` that does not have spaces.