### PR TITLE
Resolve paths before passing through to commands

### DIFF
--- a/packages/generator-single-spa/src/angular/generator-single-spa-angular.js
+++ b/packages/generator-single-spa/src/angular/generator-single-spa-angular.js
@@ -43,7 +43,7 @@ module.exports = class SingleSpaAngularGenerator extends Generator {
       command += ".cmd";
     }
 
-    this.cwd = this.options.dir || ".";
+    const cwd = path.resolve(this.options.dir || ".");
 
     const { status, signal } = spawnSync(
       command,
@@ -51,7 +51,7 @@ module.exports = class SingleSpaAngularGenerator extends Generator {
         "new",
         this.options.projectName, // name of the new workspace and initial project
         "--directory",
-        this.cwd,
+        cwd,
         // "--routing", false, TODO: Figure out how to interop with single-spa-angular's routing option so that we don't ask the user twice with opposite defaults
       ]),
       { stdio: "inherit" }
@@ -64,7 +64,7 @@ module.exports = class SingleSpaAngularGenerator extends Generator {
     } else {
       spawnSync(command, args.concat(["add", "single-spa-angular"]), {
         stdio: "inherit",
-        cwd: this.cwd,
+        cwd,
       });
 
       console.log(

--- a/packages/generator-single-spa/src/vue/generator-single-spa-vue.js
+++ b/packages/generator-single-spa/src/vue/generator-single-spa-vue.js
@@ -99,7 +99,9 @@ module.exports = class SingleSpaVueGenerator extends Generator {
     });
   }
   async finished() {
-    const usedYarn = this.fs.exists(path.resolve(projectPath, "yarn.lock"));
+    const usedYarn = this.fs.exists(
+      path.resolve(this.options.dir, this.options.projectName, "yarn.lock")
+    );
     console.log(
       chalk.bgWhite.black(
         `Project setup complete!

--- a/packages/generator-single-spa/src/vue/generator-single-spa-vue.js
+++ b/packages/generator-single-spa/src/vue/generator-single-spa-vue.js
@@ -66,11 +66,14 @@ module.exports = class SingleSpaVueGenerator extends Generator {
       command += ".cmd";
     }
 
+    const dirPath = path.resolve(this.options.dir);
+    const projectPath = path.resolve(dirPath, this.options.projectName);
+
     const { status, signal } = spawnSync(
       command,
       args.concat(["create", this.options.projectName, "--skipGetStarted"]),
       {
-        cwd: this.options.dir,
+        cwd: dirPath,
         stdio: "inherit",
       }
     );
@@ -81,11 +84,7 @@ module.exports = class SingleSpaVueGenerator extends Generator {
       process.exit(status);
     }
 
-    const pkgJsonPath = path.resolve(
-      this.options.dir,
-      this.options.projectName,
-      "package.json"
-    );
+    const pkgJsonPath = path.resolve(projectPath, "package.json");
     const pkgJson = JSON.parse(fs.readFileSync(pkgJsonPath));
     this.projectName = pkgJson.name = `@${this.options.orgName}/${this.options.projectName}`;
     fs.writeFileSync(pkgJsonPath, JSON.stringify(pkgJson, null, 2));
@@ -93,16 +92,14 @@ module.exports = class SingleSpaVueGenerator extends Generator {
     // We purposely do not attempt to install in one command using presets to avoid being too restrictive with application configuration
     spawnSync(command, args.concat(["add", "single-spa"]), {
       stdio: "inherit",
-      cwd: path.resolve(this.options.dir, this.options.projectName),
+      cwd: projectPath,
       env: Object.assign({}, process.env, {
         VUE_CLI_SKIP_DIRTY_GIT_PROMPT: true,
       }),
     });
   }
   async finished() {
-    const usedYarn = this.fs.exists(
-      path.resolve(this.options.dir, this.options.projectName, "yarn.lock")
-    );
+    const usedYarn = this.fs.exists(path.resolve(projectPath, "yarn.lock"));
     console.log(
       chalk.bgWhite.black(
         `Project setup complete!


### PR DESCRIPTION
Resolves #193

There are only two instances where we use `'.'` as the dir inside of the framework-specific generators. My suspicion is that the one that causes the bug is the Angular one since it's passed as an arg to the angular/cli, while in the Vue one its used to spawn the command with that cwd. In any case, it seems safer to use resolved paths instead of relative ones.