### PR TITLE
Make nodeKeyFilter optional

### DIFF
--- a/packages/single-spa-web-server-utils/lib/import-map-poller.js
+++ b/packages/single-spa-web-server-utils/lib/import-map-poller.js
@@ -4,6 +4,18 @@ import { applyOverrides, getOverridesFromCookies } from "import-map-overrides";
 
 let importMapPromises = {};
 
+/**
+ *
+ * @typedef {{
+ * url: string;
+ * pollInterval: number;
+ * req: import('http').IncomingMessage;
+ * allowOverrides: boolean;
+ * nodeKeyFilter?(importSpecifier: string): boolean;
+ * }} GetImportMapOptions
+ *
+ * @param {GetImportMapOptions} options
+ */
 export function getImportMaps({
   url,
   pollInterval = 30000,
@@ -22,11 +34,13 @@ export function getImportMaps({
       : originalMap;
     const nodeImportMap = _.cloneDeep(browserImportMap);
 
-    Object.keys(nodeImportMap.imports).forEach((key) => {
-      if (!nodeKeyFilter(key)) {
-        delete nodeImportMap.imports[key];
-      }
-    });
+    if (nodeKeyFilter) {
+      Object.keys(nodeImportMap.imports).forEach((key) => {
+        if (!nodeKeyFilter(key)) {
+          delete nodeImportMap.imports[key];
+        }
+      });
+    }
 
     return {
       browserImportMap,


### PR DESCRIPTION
With a consulting client we're starting to use single-spa-web-server-utils to help with inlining the import map into the HTML file (not full SSR though). Since it's not full SSR, the nodeKeyFilter option doesn't matter.