### PR TITLE
Check that remoteVersion exists before trying versionUpdateCheck

### DIFF
--- a/packages/generator-single-spa/src/generator-single-spa.js
+++ b/packages/generator-single-spa/src/generator-single-spa.js
@@ -40,7 +40,10 @@ module.exports = class SingleSpaGenerator extends Generator {
       { stdio: "pipe" }
     );
 
-    versionUpdateCheck(version, stdout.toString("utf8").trim());
+    const remoteVersion =
+      stdout && stdout.toString && stdout.toString("utf8").trim();
+
+    if (remoteVersion) versionUpdateCheck(version, remoteVersion);
   }
   async chooseDestinationDir() {
     if (!this.options.dir) {


### PR DESCRIPTION
Issue was reported on [Slack](https://single-spa.slack.com/archives/C8R6U7MT7/p1602719152061600).

```sh
$ create-single-spa
(node:66831) UnhandledPromiseRejectionWarning: TypeError: Cannot read property 'toString' of null
    at SingleSpaGenerator.initializing (/Users/joshua/.config/yarn/global/node_modules/generator-single-spa/src/generator-single-spa.js:43:40)
    at Object.<anonymous> (/Users/joshua/.config/yarn/global/node_modules/yeoman-generator/lib/index.js:991:25)
    at /Users/joshua/.config/yarn/global/node_modules/run-async/index.js:49:25
    at new Promise (<anonymous>)
    at /Users/joshua/.config/yarn/global/node_modules/run-async/index.js:26:19
    at runLoop.add.once.once (/Users/joshua/.config/yarn/global/node_modules/yeoman-generator/lib/index.js:992:11)
    at processImmediate (internal/timers.js:456:21)
(node:66831) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). To terminate the node process on unhandled promise rejection, use the CLI flag `--unhandled-rejections=strict` (see https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode). (rejection id: 2)
(node:66831) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
```
macOS 10.15.7; node v12.18.4; 

This fix is to check that a response was received from the `npm view` command before trying the version check.