### PR TITLE
Fix/angular paths again

### DIFF
--- a/packages/create-single-spa/package.json
+++ b/packages/create-single-spa/package.json
@@ -8,7 +8,7 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "generator-single-spa": "^1.17.1",
+    "generator-single-spa": "1.17.1",
     "yargs": "^14.2.0",
     "yeoman-environment": "^2.6.0"
   }

--- a/packages/generator-single-spa/src/angular/generator-single-spa-angular.js
+++ b/packages/generator-single-spa/src/angular/generator-single-spa-angular.js
@@ -44,18 +44,16 @@ module.exports = class SingleSpaAngularGenerator extends Generator {
       command += ".cmd";
     }
 
-    const cwd = path.resolve(this.options.dir || ".");
+    const cwd = path.resolve(this.options.dir);
 
     const { status, signal } = spawnSync(
       command,
       args.concat([
         "new",
         this.options.projectName, // name of the new workspace and initial project
-        "--directory",
-        cwd,
         // "--routing", false, TODO: Figure out how to interop with single-spa-angular's routing option so that we don't ask the user twice with opposite defaults
       ]),
-      { stdio: "inherit" }
+      { stdio: "inherit", cwd }
     );
 
     if (signal) {
@@ -65,7 +63,7 @@ module.exports = class SingleSpaAngularGenerator extends Generator {
     } else {
       spawnSync(command, args.concat(["add", "single-spa-angular"]), {
         stdio: "inherit",
-        cwd,
+        cwd: path.resolve(cwd, this.options.projectName),
       });
 
       console.log(

--- a/packages/generator-single-spa/src/angular/generator-single-spa-angular.js
+++ b/packages/generator-single-spa/src/angular/generator-single-spa-angular.js
@@ -2,6 +2,7 @@ const Generator = require("yeoman-generator");
 const { spawnSync } = require("child_process");
 const util = require("util");
 const path = require("path");
+const fs = require("fs");
 const commandExists = util.promisify(require("command-exists"));
 const chalk = require("chalk");
 const validate = require("../validate-naming");
@@ -45,6 +46,9 @@ module.exports = class SingleSpaAngularGenerator extends Generator {
     }
 
     const cwd = path.resolve(this.options.dir);
+
+    // `ng new` fails if cwd doesn't already exist
+    if (!fs.existsSync(cwd)) fs.mkdirSync(cwd);
 
     const { status, signal } = spawnSync(
       command,


### PR DESCRIPTION
Resolves #206 by using `dir` as the current working directory instead of the `--directory` path. The angular-cli does not support outputting project files in the current directory so we'll do the same to simplify the logic.

Also, this locks the version of generator-single-spa in create-single-spa so that they're always in lockstep. Otherwise, using an older version (eg. `npx create-single-spa@1.14.1`) will still use the latest minor version of generator-single-spa (eg. `1.17.0`). 