### PR TITLE
Remove system parser false, as it's the new default in webpack 5.

### DIFF
--- a/packages/webpack-config-single-spa/lib/webpack-config-single-spa.js
+++ b/packages/webpack-config-single-spa/lib/webpack-config-single-spa.js
@@ -50,11 +50,6 @@ function webpackConfigSingleSpa(opts) {
     module: {
       rules: [
         {
-          parser: {
-            system: false,
-          },
-        },
-        {
           test: /\.(js|ts)x?$/,
           exclude: /node_modules/,
           use: {


### PR DESCRIPTION
I found this when upgrading react-mf/api. Not only is the parser system configuration unnecessary, it actually breaks things in webpack 5 if you try to load json modules.