### PR TITLE
Moving public path to a webpack plugin instead of set-public-path.js

### DIFF
--- a/packages/generator-single-spa/src/react/generator-single-spa-react.js
+++ b/packages/generator-single-spa/src/react/generator-single-spa-react.js
@@ -156,11 +156,6 @@ module.exports = class SingleSpaReactGenerator extends Generator {
       this.options
     );
     this.fs.copyTpl(
-      this.templatePath("src/set-public-path.js"),
-      this.destinationPath(`src/set-public-path.${srcFileExtension}`),
-      this.options
-    );
-    this.fs.copyTpl(
       this.templatePath("src/main.js"),
       this.destinationPath(
         `src/${this.options.orgName}-${this.options.projectName}.${srcFileExtension}`

--- a/packages/generator-single-spa/src/react/templates/package.json
+++ b/packages/generator-single-spa/src/react/templates/package.json
@@ -41,7 +41,6 @@
     "prettier": "^2.0.4",
     "pretty-quick": "^2.0.1",
     "single-spa-react": "^2.14.0",
-    "systemjs-webpack-interop": "^2.1.2",
     "webpack": "^4.41.2",
     "webpack-cli": "^3.3.10",
     "webpack-config-single-spa-react": "^1.0.3",

--- a/packages/generator-single-spa/src/react/templates/src/main.js
+++ b/packages/generator-single-spa/src/react/templates/src/main.js
@@ -1,4 +1,3 @@
-import "./set-public-path";
 import React from "react";
 import ReactDOM from "react-dom";
 import singleSpaReact from "single-spa-react";

--- a/packages/generator-single-spa/src/react/templates/src/set-public-path.js
+++ b/packages/generator-single-spa/src/react/templates/src/set-public-path.js
@@ -1,8 +1,0 @@
-import { setPublicPath } from "systemjs-webpack-interop";
-/* This dynamically sets the webpack public path so that code splits work properly. See related:
- * https://github.com/joeldenning/systemjs-webpack-interop#what-is-this
- * https://webpack.js.org/guides/public-path/#on-the-fly
- * https://single-spa.js.org/docs/faq/#code-splits
- */
-
-setPublicPath("@<%= orgName %>/<%= projectName %>");

--- a/packages/generator-single-spa/src/util-module/generator-single-spa-util-module.js
+++ b/packages/generator-single-spa/src/util-module/generator-single-spa-util-module.js
@@ -126,11 +126,6 @@ module.exports = class SingleSpaUtilModuleGenerator extends Generator {
       this.options
     );
     this.fs.copyTpl(
-      this.templatePath("src/set-public-path.js"),
-      this.destinationPath(`src/set-public-path.${srcFileExtension}`),
-      this.options
-    );
-    this.fs.copyTpl(
       this.templatePath("src/main.js"),
       this.destinationPath(
         `src/${this.options.orgName}-${this.options.projectName}.${srcFileExtension}`

--- a/packages/generator-single-spa/src/util-module/templates/package.json
+++ b/packages/generator-single-spa/src/util-module/templates/package.json
@@ -36,7 +36,6 @@
     "jest-cli": "^25.2.7",
     "prettier": "^2.0.4",
     "pretty-quick": "^2.0.1",
-    "systemjs-webpack-interop": "^2.1.2",
     "webpack": "^4.41.2",
     "webpack-config-single-spa": "^1.0.7",
     "webpack-merge": "^4.2.2",

--- a/packages/generator-single-spa/src/util-module/templates/src/main.js
+++ b/packages/generator-single-spa/src/util-module/templates/src/main.js
@@ -1,4 +1,2 @@
-import "./set-public-path";
-
 // Anything exported from this file is importable by other in-browser modules.
 export function publicApiFunction() {}

--- a/packages/generator-single-spa/src/util-module/templates/src/set-public-path.js
+++ b/packages/generator-single-spa/src/util-module/templates/src/set-public-path.js
@@ -1,8 +1,0 @@
-import { setPublicPath } from "systemjs-webpack-interop";
-/* This dynamically sets the webpack public path so that code splits work properly. See related:
- * https://github.com/joeldenning/systemjs-webpack-interop#what-is-this
- * https://webpack.js.org/guides/public-path/#on-the-fly
- * https://single-spa.js.org/docs/faq/#code-splits
- */
-
-setPublicPath("@<%= orgName %>/<%= projectName %>");

--- a/packages/single-spa-welcome/package.json
+++ b/packages/single-spa-welcome/package.json
@@ -60,7 +60,6 @@
     "pretty-quick": "^2.0.1",
     "single-spa-react": "^2.14.0",
     "style-loader": "^1.0.1",
-    "systemjs-webpack-interop": "^2.1.2",
     "ts-config-single-spa": "^1.17.6",
     "webpack": "^4.41.2",
     "webpack-cli": "^3.3.10",

--- a/packages/single-spa-welcome/src/single-spa-welcome.js
+++ b/packages/single-spa-welcome/src/single-spa-welcome.js
@@ -1,4 +1,3 @@
-// import "./set-public-path";
 import React from "react";
 import ReactDOM from "react-dom";
 import singleSpaReact from "single-spa-react";

--- a/packages/webpack-config-single-spa/lib/webpack-config-single-spa.js
+++ b/packages/webpack-config-single-spa/lib/webpack-config-single-spa.js
@@ -4,6 +4,7 @@ const { BundleAnalyzerPlugin } = require("webpack-bundle-analyzer");
 const { UnusedFilesWebpackPlugin } = require("unused-files-webpack-plugin");
 const _HtmlWebpackPlugin = require("html-webpack-plugin");
 const StandaloneSingleSpaPlugin = require("standalone-single-spa-webpack-plugin");
+const SystemJSPublicPathWebpackPlugin = require("systemjs-webpack-interop/SystemJSPublicPathWebpackPlugin");
 
 module.exports = webpackConfigSingleSpa;
 
@@ -105,6 +106,10 @@ function webpackConfigSingleSpa(opts) {
             "**/*.stories.*",
           ],
         },
+      }),
+      new SystemJSPublicPathWebpackPlugin({
+        systemjsModuleName: `@${opts.orgName}/${opts.projectName}`,
+        rootDirectoryLevel: opts.rootDirectoryLevel,
       }),
       !isProduction && new HtmlWebpackPlugin(),
       !isProduction &&

--- a/packages/webpack-config-single-spa/package.json
+++ b/packages/webpack-config-single-spa/package.json
@@ -28,7 +28,7 @@
     "html-webpack-plugin": "^4.5.0",
     "standalone-single-spa-webpack-plugin": "^1.0.1",
     "style-loader": "^1.2.1",
-    "systemjs-webpack-interop": "^2.3.0",
+    "systemjs-webpack-interop": "^2.3.1",
     "unused-files-webpack-plugin": "^3.4.0",
     "webpack-bundle-analyzer": "^3.6.0"
   },

--- a/packages/webpack-config-single-spa/package.json
+++ b/packages/webpack-config-single-spa/package.json
@@ -28,6 +28,7 @@
     "html-webpack-plugin": "^4.5.0",
     "standalone-single-spa-webpack-plugin": "^1.0.1",
     "style-loader": "^1.2.1",
+    "systemjs-webpack-interop": "^2.3.0",
     "unused-files-webpack-plugin": "^3.4.0",
     "webpack-bundle-analyzer": "^3.6.0"
   },

--- a/packages/webpack-config-single-spa/yarn.lock
+++ b/packages/webpack-config-single-spa/yarn.lock
@@ -3355,10 +3355,10 @@ supports-color@^6.1.0:
   dependencies:
     has-flag "^3.0.0"
 
-systemjs-webpack-interop@^2.3.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/systemjs-webpack-interop/-/systemjs-webpack-interop-2.3.0.tgz#7f5adacba4fb4020a4c431d62d6dad249effdc56"
-  integrity sha512-jt69PS4CTFmL5uv52ZOHLJ7l487m6YYpdssE1nhvZXYrRBQPnVrf90bnlB+LDiOybTUadIS7uNBgQ4rCvsrAqg==
+systemjs-webpack-interop@^2.3.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/systemjs-webpack-interop/-/systemjs-webpack-interop-2.3.1.tgz#06d3d806daf2e66b57930bad1c40a2ffc0d36fb1"
+  integrity sha512-9oGeHedLJi3NrRR0OAzC6t03xhTIvb+QcMS752XACaskZQJFw6NVyi62a6+54YsrNj0oo4ejIOge1ZvLmE8ixQ==
 
 tapable@^1.0.0, tapable@^1.1.3:
   version "1.1.3"

--- a/packages/webpack-config-single-spa/yarn.lock
+++ b/packages/webpack-config-single-spa/yarn.lock
@@ -3355,6 +3355,11 @@ supports-color@^6.1.0:
   dependencies:
     has-flag "^3.0.0"
 
+systemjs-webpack-interop@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/systemjs-webpack-interop/-/systemjs-webpack-interop-2.3.0.tgz#7f5adacba4fb4020a4c431d62d6dad249effdc56"
+  integrity sha512-jt69PS4CTFmL5uv52ZOHLJ7l487m6YYpdssE1nhvZXYrRBQPnVrf90bnlB+LDiOybTUadIS7uNBgQ4rCvsrAqg==
+
 tapable@^1.0.0, tapable@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/tapable/-/tapable-1.1.3.tgz#a1fccc06b58db61fd7a45da2da44f5f3a3e67ba2"


### PR DESCRIPTION
See https://github.com/joeldenning/systemjs-webpack-interop/releases/tag/v2.2.0 and https://github.com/joeldenning/systemjs-webpack-interop#as-a-webpack-plugin