### PR TITLE
Add coverage directory to all prettierignores. Resolves #239.

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -7,3 +7,4 @@ tests/fixtures
 .DS_Store
 *.svelte
 *.js.map
+coverage

--- a/packages/generator-single-spa/src/react/templates/.prettierignore
+++ b/packages/generator-single-spa/src/react/templates/.prettierignore
@@ -4,3 +4,4 @@ yarn.lock
 yarn-error.log
 package-lock.json
 dist
+coverage

--- a/packages/generator-single-spa/src/root-config/templates/.prettierignore
+++ b/packages/generator-single-spa/src/root-config/templates/.prettierignore
@@ -6,3 +6,4 @@ package-lock.json
 LICENSE
 *.ejs
 dist
+coverage

--- a/packages/generator-single-spa/src/svelte/templates/.prettierignore
+++ b/packages/generator-single-spa/src/svelte/templates/.prettierignore
@@ -4,3 +4,4 @@ yarn.lock
 yarn-error.log
 package-lock.json
 dist/
+coverage

--- a/packages/generator-single-spa/src/util-module/templates/.prettierignore
+++ b/packages/generator-single-spa/src/util-module/templates/.prettierignore
@@ -4,3 +4,4 @@ yarn.lock
 yarn-error.log
 package-lock.json
 dist
+coverage

--- a/packages/single-spa-welcome/.prettierignore
+++ b/packages/single-spa-welcome/.prettierignore
@@ -4,3 +4,4 @@ yarn.lock
 yarn-error.log
 package-lock.json
 dist
+coverage


### PR DESCRIPTION
See #239. The coverage directory is generated by `jest --coverage` and contains an html report. It is gitignored, but also should be prettierignored