### PR TITLE
Improve typescript build times by using write-references.

### DIFF
--- a/packages/webpack-config-single-spa-ts/lib/webpack-config-single-spa-ts.js
+++ b/packages/webpack-config-single-spa-ts/lib/webpack-config-single-spa-ts.js
@@ -19,7 +19,11 @@ const modifyConfig = (opts, webpackConfig) => {
     plugins: [
       opts.webpackConfigEnv && opts.webpackConfigEnv.analyze
         ? false
-        : new ForkTsCheckerWebpackPlugin({}),
+        : new ForkTsCheckerWebpackPlugin({
+            typescript: {
+              mode: "write-references",
+            },
+          }),
     ].filter(Boolean),
     resolve: {
       extensions: [".ts", ".tsx"],


### PR DESCRIPTION
From [these docs](https://github.com/TypeStrong/fork-ts-checker-webpack-plugin#typescript-options):

> If you use the babel-loader, it's recommended to use write-references mode to improve initial compilation time.

Since we use babel-loader, I think this will improve build times. I tested locally and it seems to still work as normal.