### PR TITLE
Use single-spa-layout by default

### DIFF
--- a/.changeset/strong-camels-obey.md
+++ b/.changeset/strong-camels-obey.md
@@ -1,0 +1,5 @@
+---
+"generator-single-spa": minor
+---
+
+Use single-spa-layout by default in root configs

--- a/packages/generator-single-spa/src/root-config/generator-root-config.js
+++ b/packages/generator-single-spa/src/root-config/generator-root-config.js
@@ -44,7 +44,7 @@ module.exports = class SingleSpaRootConfigGenerator extends PnpmGenerator {
         type: "confirm",
         name: "layout",
         message: "Would you like to use single-spa Layout Engine",
-        default: false,
+        default: true,
         when: this.options.layout === undefined,
       },
       {


### PR DESCRIPTION
We started it off as false by default because single-spa-layout was new. It's now more mature.