### PR TITLE
Fix start instructions for pnpm. Resolves #278.

### DIFF
--- a/.changeset/stupid-mayflies-visit.md
+++ b/.changeset/stupid-mayflies-visit.md
@@ -1,0 +1,5 @@
+---
+"generator-single-spa": patch
+---
+
+Fix start instructions for pnpm

--- a/packages/generator-single-spa/src/react/generator-single-spa-react.js
+++ b/packages/generator-single-spa/src/react/generator-single-spa-react.js
@@ -208,7 +208,7 @@ module.exports = class SingleSpaReactGenerator extends PnpmGenerator {
         chalk.bgWhite.black(`Project setup complete!
 Steps to test your React single-spa application:
 1. Run '${this.options.packageManager} start${
-          this.options.packageManager === "npm" ? " --" : ""
+          this.options.packageManager === "yarn" ? "" : " --"
         } --port 8500'
 2. Go to http://single-spa-playground.org/playground/instant-test?name=@${
           this.options.orgName

--- a/packages/generator-single-spa/src/util-module/generator-single-spa-util-module.js
+++ b/packages/generator-single-spa/src/util-module/generator-single-spa-util-module.js
@@ -171,7 +171,7 @@ module.exports = class SingleSpaUtilModuleGenerator extends PnpmGenerator {
       console.log(
         coloredFinalInstructions(
           `1. Run '${this.options.packageManager} start${
-            this.options.packageManager === "npm" ? " --" : ""
+            this.options.packageManager === "yarn" ? "" : " --"
           } --port 8500'`
         )
       );


### PR DESCRIPTION
See #278. pnpm and npm require the extra `--` in the command. When pnpm was added as a new option, this was overlooked.