### PR TITLE
Upgrade webpack upstream dependencies

### DIFF
--- a/.changeset/twelve-shoes-eat.md
+++ b/.changeset/twelve-shoes-eat.md
@@ -1,0 +1,7 @@
+---
+"webpack-config-single-spa-react": patch
+"webpack-config-single-spa-react-ts": patch
+"webpack-config-single-spa-ts": patch
+---
+
+Upgrade webpack-config-single-spa's upstream dependencies


### PR DESCRIPTION
To force webpack-config-single-spa-react, webpack-config-single-spa-react-ts, and webpack-config-single-spa-ts to use the latest version of webpack-config-single-spa