### PR TITLE
fix: child application async chunk path conflict

### DIFF
--- a/.changeset/silver-hounds-sniff.md
+++ b/.changeset/silver-hounds-sniff.md
@@ -1,0 +1,5 @@
+---
+'webpack-config-single-spa': patch
+---
+
+fix: child application async chunk path conflict #287

--- a/packages/webpack-config-single-spa/lib/webpack-config-single-spa.js
+++ b/packages/webpack-config-single-spa/lib/webpack-config-single-spa.js
@@ -46,6 +46,7 @@ function webpackConfigSingleSpa(opts) {
       uniqueName: opts.projectName,
       devtoolNamespace: `${opts.projectName}`,
       publicPath: "",
+      jsonpFunction = `webpackJsonp_${opts.projectName}`;
     },
     module: {
       rules: [

--- a/packages/webpack-config-single-spa/lib/webpack-config-single-spa.js
+++ b/packages/webpack-config-single-spa/lib/webpack-config-single-spa.js
@@ -46,7 +46,7 @@ function webpackConfigSingleSpa(opts) {
       uniqueName: opts.projectName,
       devtoolNamespace: `${opts.projectName}`,
       publicPath: "",
-      jsonpFunction = `webpackJsonp_${opts.projectName}`;
+      jsonpFunction: `webpackJsonp_${opts.projectName}`;
     },
     module: {
       rules: [


### PR DESCRIPTION
In Webpack4, when the child application both use async route chunk( import() ), and if a file path is the same (for example, there is a utils/index.js) but the export content is different, an error will be reported.

But in webpack5, `output.jsonpFunction` value get from `package.json` => `name` field
https://webpack.js.org/blog/2020-10-10-webpack-5-release/#automatic-unique-naming