### PR TITLE
fixed generated jest config for react unable to load parcels 

### DIFF
--- a/.changeset/seven-windows-attend.md
+++ b/.changeset/seven-windows-attend.md
@@ -1,0 +1,5 @@
+---
+"generator-single-spa": patch
+---
+
+fixed generated jest config for react unable to load parcels

--- a/packages/generator-single-spa/src/react/templates/jest.config.js
+++ b/packages/generator-single-spa/src/react/templates/jest.config.js
@@ -5,6 +5,7 @@ module.exports = {
   },
   moduleNameMapper: {
     "\\.(css)$": "identity-obj-proxy",
+    "single-spa-react/parcel": "single-spa-react/lib/cjs/parcel.cjs",
   },
   setupFilesAfterEnv: ["@testing-library/jest-dom"],
 };


### PR DESCRIPTION
Changes made due to issues found here: https://github.com/single-spa/single-spa-react/issues/103

Will not fix existing projects but newly generated projects should work ok now. 
Existing projects can be manually fixed by using the example code @joeldenning provided.