### PR TITLE
Add --skipInstall. Fix tests and typescript react-jsx

### DIFF
--- a/.changeset/lemon-crews-grab.md
+++ b/.changeset/lemon-crews-grab.md
@@ -1,0 +1,5 @@
+---
+"generator-single-spa": minor
+---
+
+Support --skipInstall option

--- a/jest.config.js
+++ b/jest.config.js
@@ -4,4 +4,5 @@ module.exports = {
   testTimeout: 120000,
   testRegex: "tests\\/e2e\\/.+test.js",
   watchPathIgnorePatterns: ["<rootDir>/tests/fixtures/"],
+  globalSetup: "<rootDir>/tests/create-fixtures.js",
 };

--- a/packages/generator-single-spa/src/generator-single-spa.js
+++ b/packages/generator-single-spa/src/generator-single-spa.js
@@ -25,6 +25,10 @@ module.exports = class SingleSpaGenerator extends Generator {
       type: String,
     });
 
+    this.option("skipInstall", {
+      type: Boolean,
+    });
+
     if (args.length > 0 && !this.options.dir) {
       this.options.dir = args[0];
     }

--- a/packages/generator-single-spa/src/react/generator-single-spa-react.js
+++ b/packages/generator-single-spa/src/react/generator-single-spa-react.js
@@ -195,12 +195,14 @@ module.exports = class SingleSpaReactGenerator extends PnpmGenerator {
     }
   }
   install() {
-    this.installDependencies({
-      npm: this.options.packageManager === "npm",
-      yarn: this.options.packageManager === "yarn",
-      pnpm: this.options.packageManager === "pnpm",
-      bower: false,
-    });
+    if (!this.skipInstall) {
+      this.installDependencies({
+        npm: this.options.packageManager === "npm",
+        yarn: this.options.packageManager === "yarn",
+        pnpm: this.options.packageManager === "pnpm",
+        bower: false,
+      });
+    }
   }
   finished() {
     this.on(`${this.options.packageManager}Install:end`, () => {

--- a/packages/generator-single-spa/src/react/templates/tsconfig.json
+++ b/packages/generator-single-spa/src/react/templates/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "ts-config-single-spa",
   "compilerOptions": {
-    "jsx": "react"
+    "jsx": "react-jsx"
   },
   "include": ["src/**/*", "node_modules/@types"],
   "exclude": ["src/**/*.test*"]

--- a/packages/generator-single-spa/src/root-config/generator-root-config.js
+++ b/packages/generator-single-spa/src/root-config/generator-root-config.js
@@ -185,12 +185,14 @@ module.exports = class SingleSpaRootConfigGenerator extends PnpmGenerator {
     }
   }
   install() {
-    this.installDependencies({
-      npm: this.options.packageManager === "npm",
-      yarn: this.options.packageManager === "yarn",
-      pnpm: this.options.packageManager === "pnpm",
-      bower: false,
-    });
+    if (!this.skipInstall) {
+      this.installDependencies({
+        npm: this.options.packageManager === "npm",
+        yarn: this.options.packageManager === "yarn",
+        pnpm: this.options.packageManager === "pnpm",
+        bower: false,
+      });
+    }
   }
   finished() {
     this.on(`${this.options.packageManager}Install:end`, () => {

--- a/packages/generator-single-spa/src/svelte/generator-single-spa-svelte.js
+++ b/packages/generator-single-spa/src/svelte/generator-single-spa-svelte.js
@@ -151,12 +151,14 @@ module.exports = class SingleSpaSvelteGenerator extends PnpmGenerator {
     }
   }
   install() {
-    this.installDependencies({
-      npm: this.options.packageManager === "npm",
-      yarn: this.options.packageManager === "yarn",
-      pnpm: this.options.packageManager === "pnpm",
-      bower: false,
-    });
+    if (!this.skipInstall) {
+      this.installDependencies({
+        npm: this.options.packageManager === "npm",
+        yarn: this.options.packageManager === "yarn",
+        pnpm: this.options.packageManager === "pnpm",
+        bower: false,
+      });
+    }
   }
   finished() {
     this.on(`${this.options.packageManager}Install:end`, () => {

--- a/packages/generator-single-spa/src/util-module/generator-single-spa-util-module.js
+++ b/packages/generator-single-spa/src/util-module/generator-single-spa-util-module.js
@@ -154,12 +154,14 @@ module.exports = class SingleSpaUtilModuleGenerator extends PnpmGenerator {
     }
   }
   install() {
-    this.installDependencies({
-      npm: this.options.packageManager === "npm",
-      yarn: this.options.packageManager === "yarn",
-      pnpm: this.options.packageManager === "pnpm",
-      bower: false,
-    });
+    if (!this.skipInstall) {
+      this.installDependencies({
+        npm: this.options.packageManager === "npm",
+        yarn: this.options.packageManager === "yarn",
+        pnpm: this.options.packageManager === "pnpm",
+        bower: false,
+      });
+    }
   }
   finished() {
     this.on(`${this.options.packageManager}Install:end`, () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -194,18 +194,580 @@ importers:
       webpack-config-single-spa: link:../webpack-config-single-spa
       webpack-merge: 5.7.3
 
+  tests/fixtures/react-app-js-webpack:
+    specifiers:
+      '@babel/core': ^7.12.16
+      '@babel/eslint-parser': ^7.12.16
+      '@babel/plugin-transform-runtime': ^7.12.1
+      '@babel/preset-env': ^7.12.7
+      '@babel/preset-react': ^7.12.7
+      '@babel/runtime': ^7.12.5
+      '@testing-library/jest-dom': ^5.11.6
+      '@testing-library/react': ^11.2.2
+      babel-jest: ^26.6.3
+      concurrently: ^5.3.0
+      cross-env: ^7.0.3
+      eslint: ^7.15.0
+      eslint-config-prettier: ^7.0.0
+      eslint-config-react-important-stuff: ^3.0.0
+      eslint-plugin-prettier: ^3.2.0
+      husky: ^4.3.5
+      identity-obj-proxy: ^3.0.0
+      jest: ^26.6.3
+      jest-cli: ^26.6.3
+      prettier: ^2.2.1
+      pretty-quick: ^3.1.0
+      react: ^17.0.1
+      react-dom: ^17.0.1
+      single-spa-react: ^4.0.0
+      webpack: ^5.8.0
+      webpack-cli: ^4.2.0
+      webpack-config-single-spa-react: ^2.0.0
+      webpack-dev-server: ^4.0.0-beta.0
+      webpack-merge: ^5.4.0
+    dependencies:
+      react: 17.0.1
+      react-dom: 17.0.1_react@17.0.1
+      single-spa-react: 4.1.0_react@17.0.1
+    devDependencies:
+      '@babel/core': 7.12.16
+      '@babel/eslint-parser': 7.14.7_442e1696da38772be2d58fc500f0ec59
+      '@babel/plugin-transform-runtime': 7.12.15_@babel+core@7.12.16
+      '@babel/preset-env': 7.12.16_@babel+core@7.12.16
+      '@babel/preset-react': 7.12.13_@babel+core@7.12.16
+      '@babel/runtime': 7.12.13
+      '@testing-library/jest-dom': 5.11.9
+      '@testing-library/react': 11.2.5_react-dom@17.0.1+react@17.0.1
+      babel-jest: 26.6.3_@babel+core@7.12.16
+      concurrently: 5.3.0
+      cross-env: 7.0.3
+      eslint: 7.20.0
+      eslint-config-prettier: 7.2.0_eslint@7.20.0
+      eslint-config-react-important-stuff: 3.0.0_eslint@7.20.0
+      eslint-plugin-prettier: 3.3.1_90376326e593b529cca0740deb6f3b7f
+      husky: 4.3.8
+      identity-obj-proxy: 3.0.0
+      jest: 26.6.3
+      jest-cli: 26.6.3
+      prettier: 2.2.1
+      pretty-quick: 3.1.0_prettier@2.2.1
+      webpack: 5.22.0_webpack-cli@4.5.0
+      webpack-cli: 4.5.0_c8720de1e65240bcffbc0ce9f2c3184a
+      webpack-config-single-spa-react: link:../../../packages/webpack-config-single-spa-react
+      webpack-dev-server: 4.0.0-beta.0_webpack-cli@4.5.0+webpack@5.22.0
+      webpack-merge: 5.7.3
+
+  tests/fixtures/react-app-ts-webpack:
+    specifiers:
+      '@babel/core': ^7.12.16
+      '@babel/eslint-parser': ^7.12.16
+      '@babel/plugin-transform-runtime': ^7.12.1
+      '@babel/preset-env': ^7.12.7
+      '@babel/preset-react': ^7.12.7
+      '@babel/preset-typescript': ^7.12.7
+      '@babel/runtime': ^7.12.5
+      '@testing-library/jest-dom': ^5.11.6
+      '@testing-library/react': ^11.2.2
+      '@types/jest': ^26.0.16
+      '@types/react': ^16.9.32
+      '@types/react-dom': ^16.9.6
+      '@types/systemjs': ^6.1.0
+      '@types/testing-library__jest-dom': ^5.9.5
+      '@types/webpack-env': ^1.16.0
+      babel-jest: ^26.6.3
+      concurrently: ^5.3.0
+      cross-env: ^7.0.3
+      eslint: ^7.15.0
+      eslint-config-prettier: ^7.0.0
+      eslint-config-ts-react-important-stuff: ^3.0.0
+      eslint-plugin-prettier: ^3.2.0
+      husky: ^4.3.5
+      identity-obj-proxy: ^3.0.0
+      jest: ^26.6.3
+      jest-cli: ^26.6.3
+      prettier: ^2.2.1
+      pretty-quick: ^3.1.0
+      react: ^17.0.1
+      react-dom: ^17.0.1
+      single-spa-react: ^4.0.0
+      ts-config-single-spa: ^2.0.0
+      typescript: ^4.1.2
+      webpack: ^5.8.0
+      webpack-cli: ^4.2.0
+      webpack-config-single-spa-react: ^2.0.0
+      webpack-config-single-spa-react-ts: ^2.0.0
+      webpack-config-single-spa-ts: ^2.0.0
+      webpack-dev-server: ^4.0.0-beta.0
+      webpack-merge: ^5.4.0
+    dependencies:
+      '@types/jest': 26.0.20
+      '@types/react': 16.14.8
+      '@types/react-dom': 16.9.13
+      '@types/systemjs': 6.1.0
+      '@types/webpack-env': 1.16.0
+      react: 17.0.1
+      react-dom: 17.0.1_react@17.0.1
+      single-spa-react: 4.1.0_a3626766904e54ff7fb600102f5c3051
+    devDependencies:
+      '@babel/core': 7.12.16
+      '@babel/eslint-parser': 7.14.7_442e1696da38772be2d58fc500f0ec59
+      '@babel/plugin-transform-runtime': 7.12.15_@babel+core@7.12.16
+      '@babel/preset-env': 7.12.16_@babel+core@7.12.16
+      '@babel/preset-react': 7.12.13_@babel+core@7.12.16
+      '@babel/preset-typescript': 7.14.5_@babel+core@7.12.16
+      '@babel/runtime': 7.12.13
+      '@testing-library/jest-dom': 5.11.9
+      '@testing-library/react': 11.2.5_react-dom@17.0.1+react@17.0.1
+      '@types/testing-library__jest-dom': 5.9.5
+      babel-jest: 26.6.3_@babel+core@7.12.16
+      concurrently: 5.3.0
+      cross-env: 7.0.3
+      eslint: 7.20.0
+      eslint-config-prettier: 7.2.0_eslint@7.20.0
+      eslint-config-ts-react-important-stuff: 3.0.0_eslint@7.20.0
+      eslint-plugin-prettier: 3.3.1_90376326e593b529cca0740deb6f3b7f
+      husky: 4.3.8
+      identity-obj-proxy: 3.0.0
+      jest: 26.6.3
+      jest-cli: 26.6.3
+      prettier: 2.2.1
+      pretty-quick: 3.1.0_prettier@2.2.1
+      ts-config-single-spa: link:../../../packages/ts-config-single-spa
+      typescript: 4.1.5
+      webpack: 5.22.0_webpack-cli@4.5.0
+      webpack-cli: 4.5.0_c8720de1e65240bcffbc0ce9f2c3184a
+      webpack-config-single-spa-react: link:../../../packages/webpack-config-single-spa-react
+      webpack-config-single-spa-react-ts: link:../../../packages/webpack-config-single-spa-react-ts
+      webpack-config-single-spa-ts: link:../../../packages/webpack-config-single-spa-ts
+      webpack-dev-server: 4.0.0-beta.0_webpack-cli@4.5.0+webpack@5.22.0
+      webpack-merge: 5.7.3
+
+  tests/fixtures/root-config-js-webpack:
+    specifiers:
+      '@babel/core': ^7.12.16
+      '@babel/eslint-parser': ^7.12.16
+      '@babel/plugin-transform-runtime': ^7.12.1
+      '@babel/preset-env': ^7.12.7
+      '@babel/runtime': ^7.12.5
+      '@types/jest': ^26.0.16
+      '@types/systemjs': ^6.1.0
+      concurrently: ^5.3.0
+      cross-env: ^7.0.3
+      eslint: ^7.15.0
+      eslint-config-important-stuff: ^1.1.0
+      eslint-config-prettier: ^7.0.0
+      eslint-plugin-prettier: ^3.2.0
+      html-webpack-plugin: ^5.3.1
+      husky: ^4.3.5
+      jest: ^26.6.3
+      jest-cli: ^26.6.3
+      prettier: ^2.2.1
+      pretty-quick: ^3.1.0
+      serve: ^11.3.2
+      single-spa: ^5.8.2
+      webpack: ^5.8.0
+      webpack-cli: ^4.2.0
+      webpack-config-single-spa: ^2.0.0
+      webpack-dev-server: ^4.0.0-beta.0
+      webpack-merge: ^5.5.0
+    dependencies:
+      '@types/jest': 26.0.20
+      '@types/systemjs': 6.1.0
+      single-spa: 5.9.3
+    devDependencies:
+      '@babel/core': 7.12.16
+      '@babel/eslint-parser': 7.14.7_442e1696da38772be2d58fc500f0ec59
+      '@babel/plugin-transform-runtime': 7.12.15_@babel+core@7.12.16
+      '@babel/preset-env': 7.12.16_@babel+core@7.12.16
+      '@babel/runtime': 7.12.13
+      concurrently: 5.3.0
+      cross-env: 7.0.3
+      eslint: 7.20.0
+      eslint-config-important-stuff: 1.1.0
+      eslint-config-prettier: 7.2.0_eslint@7.20.0
+      eslint-plugin-prettier: 3.3.1_90376326e593b529cca0740deb6f3b7f
+      html-webpack-plugin: 5.3.2_webpack@5.22.0
+      husky: 4.3.8
+      jest: 26.6.3
+      jest-cli: 26.6.3
+      prettier: 2.2.1
+      pretty-quick: 3.1.0_prettier@2.2.1
+      serve: 11.3.2
+      webpack: 5.22.0_webpack-cli@4.5.0
+      webpack-cli: 4.5.0_c8720de1e65240bcffbc0ce9f2c3184a
+      webpack-config-single-spa: link:../../../packages/webpack-config-single-spa
+      webpack-dev-server: 4.0.0-beta.0_webpack-cli@4.5.0+webpack@5.22.0
+      webpack-merge: 5.7.3
+
+  tests/fixtures/root-config-js-webpack-layout:
+    specifiers:
+      '@babel/core': ^7.12.16
+      '@babel/eslint-parser': ^7.12.16
+      '@babel/plugin-transform-runtime': ^7.12.1
+      '@babel/preset-env': ^7.12.7
+      '@babel/runtime': ^7.12.5
+      '@types/jest': ^26.0.16
+      '@types/systemjs': ^6.1.0
+      concurrently: ^5.3.0
+      cross-env: ^7.0.3
+      eslint: ^7.15.0
+      eslint-config-important-stuff: ^1.1.0
+      eslint-config-prettier: ^7.0.0
+      eslint-plugin-prettier: ^3.2.0
+      html-webpack-plugin: ^5.3.1
+      husky: ^4.3.5
+      jest: ^26.6.3
+      jest-cli: ^26.6.3
+      prettier: ^2.2.1
+      pretty-quick: ^3.1.0
+      serve: ^11.3.2
+      single-spa: ^5.8.2
+      single-spa-layout: 1.5.4
+      webpack: ^5.8.0
+      webpack-cli: ^4.2.0
+      webpack-config-single-spa: ^2.0.0
+      webpack-dev-server: ^4.0.0-beta.0
+      webpack-merge: ^5.5.0
+    dependencies:
+      '@types/jest': 26.0.20
+      '@types/systemjs': 6.1.0
+      single-spa: 5.9.3
+      single-spa-layout: 1.5.4
+    devDependencies:
+      '@babel/core': 7.12.16
+      '@babel/eslint-parser': 7.14.7_442e1696da38772be2d58fc500f0ec59
+      '@babel/plugin-transform-runtime': 7.12.15_@babel+core@7.12.16
+      '@babel/preset-env': 7.12.16_@babel+core@7.12.16
+      '@babel/runtime': 7.12.13
+      concurrently: 5.3.0
+      cross-env: 7.0.3
+      eslint: 7.20.0
+      eslint-config-important-stuff: 1.1.0
+      eslint-config-prettier: 7.2.0_eslint@7.20.0
+      eslint-plugin-prettier: 3.3.1_90376326e593b529cca0740deb6f3b7f
+      html-webpack-plugin: 5.3.2_webpack@5.22.0
+      husky: 4.3.8
+      jest: 26.6.3
+      jest-cli: 26.6.3
+      prettier: 2.2.1
+      pretty-quick: 3.1.0_prettier@2.2.1
+      serve: 11.3.2
+      webpack: 5.22.0_webpack-cli@4.5.0
+      webpack-cli: 4.5.0_c8720de1e65240bcffbc0ce9f2c3184a
+      webpack-config-single-spa: link:../../../packages/webpack-config-single-spa
+      webpack-dev-server: 4.0.0-beta.0_webpack-cli@4.5.0+webpack@5.22.0
+      webpack-merge: 5.7.3
+
+  tests/fixtures/root-config-ts-webpack:
+    specifiers:
+      '@babel/core': ^7.12.16
+      '@babel/eslint-parser': ^7.12.16
+      '@babel/plugin-transform-runtime': ^7.12.1
+      '@babel/preset-env': ^7.12.7
+      '@babel/preset-typescript': ^7.12.7
+      '@babel/runtime': ^7.12.5
+      '@types/jest': ^26.0.16
+      '@types/systemjs': ^6.1.0
+      '@types/webpack-env': ^1.16.0
+      concurrently: ^5.3.0
+      cross-env: ^7.0.3
+      eslint: ^7.15.0
+      eslint-config-prettier: ^7.0.0
+      eslint-config-ts-important-stuff: ^1.1.0
+      eslint-plugin-prettier: ^3.2.0
+      html-webpack-plugin: ^5.3.1
+      husky: ^4.3.5
+      jest: ^26.6.3
+      jest-cli: ^26.6.3
+      prettier: ^2.2.1
+      pretty-quick: ^3.1.0
+      serve: ^11.3.2
+      single-spa: ^5.8.2
+      ts-config-single-spa: ^2.0.0
+      typescript: ^4.1.2
+      webpack: ^5.8.0
+      webpack-cli: ^4.2.0
+      webpack-config-single-spa-ts: ^2.0.0
+      webpack-dev-server: ^4.0.0-beta.0
+      webpack-merge: ^5.5.0
+    dependencies:
+      '@types/jest': 26.0.20
+      '@types/systemjs': 6.1.0
+      '@types/webpack-env': 1.16.0
+      single-spa: 5.9.3
+    devDependencies:
+      '@babel/core': 7.12.16
+      '@babel/eslint-parser': 7.14.7_442e1696da38772be2d58fc500f0ec59
+      '@babel/plugin-transform-runtime': 7.12.15_@babel+core@7.12.16
+      '@babel/preset-env': 7.12.16_@babel+core@7.12.16
+      '@babel/preset-typescript': 7.14.5_@babel+core@7.12.16
+      '@babel/runtime': 7.12.13
+      concurrently: 5.3.0
+      cross-env: 7.0.3
+      eslint: 7.20.0
+      eslint-config-prettier: 7.2.0_eslint@7.20.0
+      eslint-config-ts-important-stuff: 1.1.0
+      eslint-plugin-prettier: 3.3.1_90376326e593b529cca0740deb6f3b7f
+      html-webpack-plugin: 5.3.2_webpack@5.22.0
+      husky: 4.3.8
+      jest: 26.6.3
+      jest-cli: 26.6.3
+      prettier: 2.2.1
+      pretty-quick: 3.1.0_prettier@2.2.1
+      serve: 11.3.2
+      ts-config-single-spa: link:../../../packages/ts-config-single-spa
+      typescript: 4.1.5
+      webpack: 5.22.0_webpack-cli@4.5.0
+      webpack-cli: 4.5.0_c8720de1e65240bcffbc0ce9f2c3184a
+      webpack-config-single-spa-ts: link:../../../packages/webpack-config-single-spa-ts
+      webpack-dev-server: 4.0.0-beta.0_webpack-cli@4.5.0+webpack@5.22.0
+      webpack-merge: 5.7.3
+
+  tests/fixtures/root-config-ts-webpack-layout:
+    specifiers:
+      '@babel/core': ^7.12.16
+      '@babel/eslint-parser': ^7.12.16
+      '@babel/plugin-transform-runtime': ^7.12.1
+      '@babel/preset-env': ^7.12.7
+      '@babel/preset-typescript': ^7.12.7
+      '@babel/runtime': ^7.12.5
+      '@types/jest': ^26.0.16
+      '@types/systemjs': ^6.1.0
+      '@types/webpack-env': ^1.16.0
+      concurrently: ^5.3.0
+      cross-env: ^7.0.3
+      eslint: ^7.15.0
+      eslint-config-prettier: ^7.0.0
+      eslint-config-ts-important-stuff: ^1.1.0
+      eslint-plugin-prettier: ^3.2.0
+      html-webpack-plugin: ^5.3.1
+      husky: ^4.3.5
+      jest: ^26.6.3
+      jest-cli: ^26.6.3
+      prettier: ^2.2.1
+      pretty-quick: ^3.1.0
+      serve: ^11.3.2
+      single-spa: ^5.8.2
+      single-spa-layout: 1.5.4
+      ts-config-single-spa: ^2.0.0
+      typescript: ^4.1.2
+      webpack: ^5.8.0
+      webpack-cli: ^4.2.0
+      webpack-config-single-spa-ts: ^2.0.0
+      webpack-dev-server: ^4.0.0-beta.0
+      webpack-merge: ^5.5.0
+    dependencies:
+      '@types/jest': 26.0.20
+      '@types/systemjs': 6.1.0
+      '@types/webpack-env': 1.16.0
+      single-spa: 5.9.3
+      single-spa-layout: 1.5.4
+    devDependencies:
+      '@babel/core': 7.12.16
+      '@babel/eslint-parser': 7.14.7_442e1696da38772be2d58fc500f0ec59
+      '@babel/plugin-transform-runtime': 7.12.15_@babel+core@7.12.16
+      '@babel/preset-env': 7.12.16_@babel+core@7.12.16
+      '@babel/preset-typescript': 7.14.5_@babel+core@7.12.16
+      '@babel/runtime': 7.12.13
+      concurrently: 5.3.0
+      cross-env: 7.0.3
+      eslint: 7.20.0
+      eslint-config-prettier: 7.2.0_eslint@7.20.0
+      eslint-config-ts-important-stuff: 1.1.0
+      eslint-plugin-prettier: 3.3.1_90376326e593b529cca0740deb6f3b7f
+      html-webpack-plugin: 5.3.2_webpack@5.22.0
+      husky: 4.3.8
+      jest: 26.6.3
+      jest-cli: 26.6.3
+      prettier: 2.2.1
+      pretty-quick: 3.1.0_prettier@2.2.1
+      serve: 11.3.2
+      ts-config-single-spa: link:../../../packages/ts-config-single-spa
+      typescript: 4.1.5
+      webpack: 5.22.0_webpack-cli@4.5.0
+      webpack-cli: 4.5.0_c8720de1e65240bcffbc0ce9f2c3184a
+      webpack-config-single-spa-ts: link:../../../packages/webpack-config-single-spa-ts
+      webpack-dev-server: 4.0.0-beta.0_webpack-cli@4.5.0+webpack@5.22.0
+      webpack-merge: 5.7.3
+
+  tests/fixtures/svelte-app-js:
+    specifiers:
+      '@babel/core': ^7.12.9
+      '@babel/preset-env': ^7.12.7
+      '@rollup/plugin-commonjs': ^17.0.0
+      '@rollup/plugin-node-resolve': ^11.0.0
+      '@testing-library/jest-dom': ^5.11.6
+      '@testing-library/svelte': ^3.0.0
+      babel-jest: ^26.6.3
+      jest: ^26.6.3
+      prettier: ^2.2.1
+      prettier-plugin-svelte: ^1.4.2
+      rollup: ^2.34.2
+      rollup-plugin-livereload: ^2.0.0
+      rollup-plugin-svelte: ^7.0.0
+      rollup-plugin-terser: ^7.0.2
+      single-spa-svelte: ^2.1.0
+      sirv-cli: ^1.0.10
+      svelte: ^3.31.0
+      svelte-jester: ^1.1.5
+    dependencies:
+      single-spa-svelte: 2.1.1
+      sirv-cli: 1.0.12
+    devDependencies:
+      '@babel/core': 7.12.16
+      '@babel/preset-env': 7.12.16_@babel+core@7.12.16
+      '@rollup/plugin-commonjs': 17.1.0_rollup@2.52.3
+      '@rollup/plugin-node-resolve': 11.2.1_rollup@2.52.3
+      '@testing-library/jest-dom': 5.11.9
+      '@testing-library/svelte': 3.0.3_svelte@3.38.3
+      babel-jest: 26.6.3_@babel+core@7.12.16
+      jest: 26.6.3
+      prettier: 2.2.1
+      prettier-plugin-svelte: 1.4.2_prettier@2.2.1+svelte@3.38.3
+      rollup: 2.52.3
+      rollup-plugin-livereload: 2.0.0
+      rollup-plugin-svelte: 7.1.0_rollup@2.52.3+svelte@3.38.3
+      rollup-plugin-terser: 7.0.2_rollup@2.52.3
+      svelte: 3.38.3
+      svelte-jester: 1.7.0_jest@26.6.3+svelte@3.38.3
+
+  tests/fixtures/util-module-js-webpack:
+    specifiers:
+      '@babel/core': ^7.12.16
+      '@babel/eslint-parser': ^7.12.16
+      '@babel/plugin-transform-runtime': ^7.12.1
+      '@babel/preset-env': ^7.12.7
+      '@babel/runtime': ^7.12.5
+      '@types/jest': ^26.0.16
+      '@types/systemjs': ^6.1.0
+      babel-jest: ^26.6.3
+      concurrently: ^5.3.0
+      cross-env: ^7.0.3
+      eslint: ^7.15.0
+      eslint-config-important-stuff: ^1.1.0
+      eslint-config-prettier: ^7.0.0
+      eslint-plugin-prettier: ^3.2.0
+      husky: ^4.3.5
+      identity-obj-proxy: ^3.0.0
+      jest: ^26.6.3
+      jest-cli: ^26.6.3
+      prettier: ^2.2.1
+      pretty-quick: ^3.1.0
+      webpack: ^5.8.0
+      webpack-cli: ^4.2.0
+      webpack-config-single-spa: ^2.0.0
+      webpack-dev-server: ^4.0.0-beta.0
+      webpack-merge: ^5.4.0
+    dependencies:
+      '@types/jest': 26.0.20
+      '@types/systemjs': 6.1.0
+    devDependencies:
+      '@babel/core': 7.12.16
+      '@babel/eslint-parser': 7.14.7_442e1696da38772be2d58fc500f0ec59
+      '@babel/plugin-transform-runtime': 7.12.15_@babel+core@7.12.16
+      '@babel/preset-env': 7.12.16_@babel+core@7.12.16
+      '@babel/runtime': 7.12.13
+      babel-jest: 26.6.3_@babel+core@7.12.16
+      concurrently: 5.3.0
+      cross-env: 7.0.3
+      eslint: 7.20.0
+      eslint-config-important-stuff: 1.1.0
+      eslint-config-prettier: 7.2.0_eslint@7.20.0
+      eslint-plugin-prettier: 3.3.1_90376326e593b529cca0740deb6f3b7f
+      husky: 4.3.8
+      identity-obj-proxy: 3.0.0
+      jest: 26.6.3
+      jest-cli: 26.6.3
+      prettier: 2.2.1
+      pretty-quick: 3.1.0_prettier@2.2.1
+      webpack: 5.22.0_webpack-cli@4.5.0
+      webpack-cli: 4.5.0_c8720de1e65240bcffbc0ce9f2c3184a
+      webpack-config-single-spa: link:../../../packages/webpack-config-single-spa
+      webpack-dev-server: 4.0.0-beta.0_webpack-cli@4.5.0+webpack@5.22.0
+      webpack-merge: 5.7.3
+
+  tests/fixtures/util-module-ts-webpack:
+    specifiers:
+      '@babel/core': ^7.12.16
+      '@babel/eslint-parser': ^7.12.16
+      '@babel/plugin-transform-runtime': ^7.12.1
+      '@babel/preset-env': ^7.12.7
+      '@babel/preset-typescript': ^7.12.7
+      '@babel/runtime': ^7.12.5
+      '@types/jest': ^26.0.16
+      '@types/systemjs': ^6.1.0
+      '@types/webpack-env': ^1.16.0
+      babel-jest: ^26.6.3
+      concurrently: ^5.3.0
+      cross-env: ^7.0.3
+      eslint: ^7.15.0
+      eslint-config-prettier: ^7.0.0
+      eslint-config-ts-important-stuff: ^1.1.0
+      eslint-plugin-prettier: ^3.2.0
+      husky: ^4.3.5
+      identity-obj-proxy: ^3.0.0
+      jest: ^26.6.3
+      jest-cli: ^26.6.3
+      prettier: ^2.2.1
+      pretty-quick: ^3.1.0
+      ts-config-single-spa: ^2.0.0
+      typescript: ^4.1.2
+      webpack: ^5.8.0
+      webpack-cli: ^4.2.0
+      webpack-config-single-spa-ts: ^2.0.0
+      webpack-dev-server: ^4.0.0-beta.0
+      webpack-merge: ^5.4.0
+    dependencies:
+      '@types/jest': 26.0.20
+      '@types/systemjs': 6.1.0
+      '@types/webpack-env': 1.16.0
+    devDependencies:
+      '@babel/core': 7.12.16
+      '@babel/eslint-parser': 7.14.7_442e1696da38772be2d58fc500f0ec59
+      '@babel/plugin-transform-runtime': 7.12.15_@babel+core@7.12.16
+      '@babel/preset-env': 7.12.16_@babel+core@7.12.16
+      '@babel/preset-typescript': 7.14.5_@babel+core@7.12.16
+      '@babel/runtime': 7.12.13
+      babel-jest: 26.6.3_@babel+core@7.12.16
+      concurrently: 5.3.0
+      cross-env: 7.0.3
+      eslint: 7.20.0
+      eslint-config-prettier: 7.2.0_eslint@7.20.0
+      eslint-config-ts-important-stuff: 1.1.0
+      eslint-plugin-prettier: 3.3.1_90376326e593b529cca0740deb6f3b7f
+      husky: 4.3.8
+      identity-obj-proxy: 3.0.0
+      jest: 26.6.3
+      jest-cli: 26.6.3
+      prettier: 2.2.1
+      pretty-quick: 3.1.0_prettier@2.2.1
+      ts-config-single-spa: link:../../../packages/ts-config-single-spa
+      typescript: 4.1.5
+      webpack: 5.22.0_webpack-cli@4.5.0
+      webpack-cli: 4.5.0_c8720de1e65240bcffbc0ce9f2c3184a
+      webpack-config-single-spa-ts: link:../../../packages/webpack-config-single-spa-ts
+      webpack-dev-server: 4.0.0-beta.0_webpack-cli@4.5.0+webpack@5.22.0
+      webpack-merge: 5.7.3
+
 packages:
 
   /@babel/code-frame/7.12.11:
     resolution: {integrity: sha512-Zt1yodBx1UcyiePMSkWnU4hPqhwq7hGi2nFL1LeA3EUl+q2LQx16MISgJ0+z7dnmgvP9QtIleuETGOiOH1RcIw==}
     dependencies:
-      '@babel/highlight': 7.12.13
+      '@babel/highlight': 7.14.5
     dev: true
 
   /@babel/code-frame/7.12.13:
     resolution: {integrity: sha512-HV1Cm0Q3ZrpCR93tkWOYiuYIgLxZXZFVG2VgK+MBWjUqZTundupbfx2aXarXuw5Ko5aMcjtJgbSs4vUGBS5v6g==}
     dependencies:
       '@babel/highlight': 7.12.13
+
+  /@babel/code-frame/7.14.5:
+    resolution: {integrity: sha512-9pzDqyc6OLDaqe+zbACgFkb6fKMNG6CObKpnYXChRsvYGyEdc7CA2BaqeOM+vOtCS5ndmJicPJhKAwYRI6UfFw==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/highlight': 7.14.5
+    dev: true
 
   /@babel/compat-data/7.12.13:
     resolution: {integrity: sha512-U/hshG5R+SIoW7HVWIdmy1cB7s3ki+r3FpyEZiCgpi4tFgPnX/vynY80ZGSASOIrUM6O7VxOgCZgdt7h97bUGg==}
@@ -215,23 +777,37 @@ packages:
     resolution: {integrity: sha512-t/hHIB504wWceOeaOoONOhu+gX+hpjfeN6YRBT209X/4sibZQfSF1I0HFRRlBe97UZZosGx5XwUg1ZgNbelmNw==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/code-frame': 7.12.13
-      '@babel/generator': 7.13.9
+      '@babel/code-frame': 7.14.5
+      '@babel/generator': 7.14.5
       '@babel/helper-module-transforms': 7.12.13
       '@babel/helpers': 7.12.13
-      '@babel/parser': 7.13.9
-      '@babel/template': 7.12.13
-      '@babel/traverse': 7.13.0
-      '@babel/types': 7.13.0
+      '@babel/parser': 7.14.7
+      '@babel/template': 7.14.5
+      '@babel/traverse': 7.14.7
+      '@babel/types': 7.14.5
       convert-source-map: 1.7.0
       debug: 4.3.1
       gensync: 1.0.0-beta.2
       json5: 2.2.0
-      lodash: 4.17.20
+      lodash: 4.17.21
       semver: 5.7.1
       source-map: 0.5.7
     transitivePeerDependencies:
       - supports-color
+    dev: true
+
+  /@babel/eslint-parser/7.14.7_442e1696da38772be2d58fc500f0ec59:
+    resolution: {integrity: sha512-6WPwZqO5priAGIwV6msJcdc9TsEPzYeYdS/Xuoap+/ihkgN6dzHp2bcAAwyWZ5bLzk0vvjDmKvRwkqNaiJ8BiQ==}
+    engines: {node: ^10.13.0 || ^12.13.0 || >=14.0.0}
+    peerDependencies:
+      '@babel/core': '>=7.11.0'
+      eslint: '>=7.5.0'
+    dependencies:
+      '@babel/core': 7.12.16
+      eslint: 7.20.0
+      eslint-scope: 5.1.1
+      eslint-visitor-keys: 2.1.0
+      semver: 6.3.0
     dev: true
 
   /@babel/generator/7.13.9:
@@ -242,17 +818,33 @@ packages:
       source-map: 0.5.7
     dev: true
 
+  /@babel/generator/7.14.5:
+    resolution: {integrity: sha512-y3rlP+/G25OIX3mYKKIOlQRcqj7YgrvHxOLbVmyLJ9bPmi5ttvUmpydVjcFjZphOktWuA7ovbx91ECloWTfjIA==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/types': 7.14.5
+      jsesc: 2.5.2
+      source-map: 0.5.7
+    dev: true
+
   /@babel/helper-annotate-as-pure/7.12.13:
     resolution: {integrity: sha512-7YXfX5wQ5aYM/BOlbSccHDbuXXFPxeoUmfWtz8le2yTkTZc+BxsiEnENFoi2SlmA8ewDkG2LgIMIVzzn2h8kfw==}
     dependencies:
       '@babel/types': 7.13.0
     dev: true
 
+  /@babel/helper-annotate-as-pure/7.14.5:
+    resolution: {integrity: sha512-EivH9EgBIb+G8ij1B2jAwSH36WnGvkQSEC6CkX/6v6ZFlw5fVOHvsgGF4uiEHO2GzMvunZb6tDLQEQSdrdocrA==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/types': 7.14.5
+    dev: true
+
   /@babel/helper-builder-binary-assignment-operator-visitor/7.12.13:
     resolution: {integrity: sha512-CZOv9tGphhDRlVjVkAgm8Nhklm9RzSmWpX2my+t7Ua/KT616pEzXsQCjinzvkRvHWJ9itO4f296efroX23XCMA==}
     dependencies:
       '@babel/helper-explode-assignable-expression': 7.12.13
-      '@babel/types': 7.13.0
+      '@babel/types': 7.14.5
     dev: true
 
   /@babel/helper-compilation-targets/7.12.16_@babel+core@7.12.16:
@@ -262,22 +854,24 @@ packages:
     dependencies:
       '@babel/compat-data': 7.12.13
       '@babel/core': 7.12.16
-      '@babel/helper-validator-option': 7.12.17
+      '@babel/helper-validator-option': 7.14.5
       browserslist: 4.16.3
       semver: 5.7.1
     dev: true
 
-  /@babel/helper-create-class-features-plugin/7.13.8_@babel+core@7.12.16:
-    resolution: {integrity: sha512-qioaRrKHQbn4hkRKDHbnuQ6kAxmmOF+kzKGnIfxPK4j2rckSJCpKzr/SSTlohSCiE3uAQpNDJ9FIh4baeE8W+w==}
+  /@babel/helper-create-class-features-plugin/7.14.6_@babel+core@7.12.16:
+    resolution: {integrity: sha512-Z6gsfGofTxH/+LQXqYEK45kxmcensbzmk/oi8DmaQytlQCgqNZt9XQF8iqlI/SeXWVjaMNxvYvzaYw+kh42mDg==}
+    engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
       '@babel/core': 7.12.16
-      '@babel/helper-function-name': 7.12.13
-      '@babel/helper-member-expression-to-functions': 7.13.0
-      '@babel/helper-optimise-call-expression': 7.12.13
-      '@babel/helper-replace-supers': 7.13.0
-      '@babel/helper-split-export-declaration': 7.12.13
+      '@babel/helper-annotate-as-pure': 7.14.5
+      '@babel/helper-function-name': 7.14.5
+      '@babel/helper-member-expression-to-functions': 7.14.7
+      '@babel/helper-optimise-call-expression': 7.14.5
+      '@babel/helper-replace-supers': 7.14.5
+      '@babel/helper-split-export-declaration': 7.14.5
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -288,14 +882,14 @@ packages:
       '@babel/core': ^7.0.0
     dependencies:
       '@babel/core': 7.12.16
-      '@babel/helper-annotate-as-pure': 7.12.13
+      '@babel/helper-annotate-as-pure': 7.14.5
       regexpu-core: 4.7.1
     dev: true
 
   /@babel/helper-explode-assignable-expression/7.12.13:
     resolution: {integrity: sha512-5loeRNvMo9mx1dA/d6yNi+YiKziJZFylZnCo1nmFF4qPU4yJ14abhWESuSMQSlQxWdxdOFzxXjk/PpfudTtYyw==}
     dependencies:
-      '@babel/types': 7.13.0
+      '@babel/types': 7.14.5
     dev: true
 
   /@babel/helper-function-name/7.12.13:
@@ -306,73 +900,98 @@ packages:
       '@babel/types': 7.13.0
     dev: true
 
+  /@babel/helper-function-name/7.14.5:
+    resolution: {integrity: sha512-Gjna0AsXWfFvrAuX+VKcN/aNNWonizBj39yGwUzVDVTlMYJMK2Wp6xdpy72mfArFq5uK+NOuexfzZlzI1z9+AQ==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/helper-get-function-arity': 7.14.5
+      '@babel/template': 7.14.5
+      '@babel/types': 7.14.5
+    dev: true
+
   /@babel/helper-get-function-arity/7.12.13:
     resolution: {integrity: sha512-DjEVzQNz5LICkzN0REdpD5prGoidvbdYk1BVgRUOINaWJP2t6avB27X1guXK1kXNrX0WMfsrm1A/ZBthYuIMQg==}
     dependencies:
       '@babel/types': 7.13.0
     dev: true
 
-  /@babel/helper-hoist-variables/7.12.13:
-    resolution: {integrity: sha512-KSC5XSj5HreRhYQtZ3cnSnQwDzgnbdUDEFsxkN0m6Q3WrCRt72xrnZ8+h+pX7YxM7hr87zIO3a/v5p/H3TrnVw==}
+  /@babel/helper-get-function-arity/7.14.5:
+    resolution: {integrity: sha512-I1Db4Shst5lewOM4V+ZKJzQ0JGGaZ6VY1jYvMghRjqs6DWgxLCIyFt30GlnKkfUeFLpJt2vzbMVEXVSXlIFYUg==}
+    engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.13.0
+      '@babel/types': 7.14.5
     dev: true
 
-  /@babel/helper-member-expression-to-functions/7.13.0:
-    resolution: {integrity: sha512-yvRf8Ivk62JwisqV1rFRMxiSMDGnN6KH1/mDMmIrij4jztpQNRoHqqMG3U6apYbGRPJpgPalhva9Yd06HlUxJQ==}
+  /@babel/helper-hoist-variables/7.14.5:
+    resolution: {integrity: sha512-R1PXiz31Uc0Vxy4OEOm07x0oSjKAdPPCh3tPivn/Eo8cvz6gveAeuyUUPB21Hoiif0uoPQSSdhIPS3352nvdyQ==}
+    engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.13.0
+      '@babel/types': 7.14.5
+    dev: true
+
+  /@babel/helper-member-expression-to-functions/7.14.7:
+    resolution: {integrity: sha512-TMUt4xKxJn6ccjcOW7c4hlwyJArizskAhoSTOCkA0uZ+KghIaci0Qg9R043kUMWI9mtQfgny+NQ5QATnZ+paaA==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/types': 7.14.5
     dev: true
 
   /@babel/helper-module-imports/7.12.13:
     resolution: {integrity: sha512-NGmfvRp9Rqxy0uHSSVP+SRIW1q31a7Ji10cLBcqSDUngGentY4FRiHOFZFE1CLU5eiL0oE8reH7Tg1y99TDM/g==}
     dependencies:
-      '@babel/types': 7.13.0
+      '@babel/types': 7.14.5
     dev: true
 
   /@babel/helper-module-transforms/7.12.13:
     resolution: {integrity: sha512-acKF7EjqOR67ASIlDTupwkKM1eUisNAjaSduo5Cz+793ikfnpe7p4Q7B7EWU2PCoSTPWsQkR7hRUWEIZPiVLGA==}
     dependencies:
       '@babel/helper-module-imports': 7.12.13
-      '@babel/helper-replace-supers': 7.13.0
+      '@babel/helper-replace-supers': 7.14.5
       '@babel/helper-simple-access': 7.12.13
-      '@babel/helper-split-export-declaration': 7.12.13
-      '@babel/helper-validator-identifier': 7.12.11
-      '@babel/template': 7.12.13
-      '@babel/traverse': 7.13.0
-      '@babel/types': 7.13.0
-      lodash: 4.17.20
+      '@babel/helper-split-export-declaration': 7.14.5
+      '@babel/helper-validator-identifier': 7.14.5
+      '@babel/template': 7.14.5
+      '@babel/traverse': 7.14.7
+      '@babel/types': 7.14.5
+      lodash: 4.17.21
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@babel/helper-optimise-call-expression/7.12.13:
-    resolution: {integrity: sha512-BdWQhoVJkp6nVjB7nkFWcn43dkprYauqtk++Py2eaf/GRDFm5BxRqEIZCiHlZUGAVmtwKcsVL1dC68WmzeFmiA==}
+  /@babel/helper-optimise-call-expression/7.14.5:
+    resolution: {integrity: sha512-IqiLIrODUOdnPU9/F8ib1Fx2ohlgDhxnIDU7OEVi+kAbEZcyiF7BLU8W6PfvPi9LzztjS7kcbzbmL7oG8kD6VA==}
+    engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.13.0
+      '@babel/types': 7.14.5
     dev: true
 
   /@babel/helper-plugin-utils/7.13.0:
     resolution: {integrity: sha512-ZPafIPSwzUlAoWT8DKs1W2VyF2gOWthGd5NGFMsBcMMol+ZhK+EQY/e6V96poa6PA/Bh+C9plWN0hXO1uB8AfQ==}
     dev: true
 
+  /@babel/helper-plugin-utils/7.14.5:
+    resolution: {integrity: sha512-/37qQCE3K0vvZKwoK4XU/irIJQdIfCJuhU5eKnNxpFDsOkgFaUAwbv+RYw6eYgsC0E4hS7r5KqGULUogqui0fQ==}
+    engines: {node: '>=6.9.0'}
+    dev: true
+
   /@babel/helper-remap-async-to-generator/7.12.13:
     resolution: {integrity: sha512-Qa6PU9vNcj1NZacZZI1Mvwt+gXDH6CTfgAkSjeRMLE8HxtDK76+YDId6NQR+z7Rgd5arhD2cIbS74r0SxD6PDA==}
     dependencies:
-      '@babel/helper-annotate-as-pure': 7.12.13
+      '@babel/helper-annotate-as-pure': 7.14.5
       '@babel/helper-wrap-function': 7.12.13
-      '@babel/types': 7.13.0
+      '@babel/types': 7.14.5
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@babel/helper-replace-supers/7.13.0:
-    resolution: {integrity: sha512-Segd5me1+Pz+rmN/NFBOplMbZG3SqRJOBlY+mA0SxAv6rjj7zJqr1AVr3SfzUVTLCv7ZLU5FycOM/SBGuLPbZw==}
+  /@babel/helper-replace-supers/7.14.5:
+    resolution: {integrity: sha512-3i1Qe9/8x/hCHINujn+iuHy+mMRLoc77b2nI9TB0zjH1hvn9qGlXjWlggdwUcju36PkPCy/lpM7LLUdcTyH4Ow==}
+    engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/helper-member-expression-to-functions': 7.13.0
-      '@babel/helper-optimise-call-expression': 7.12.13
-      '@babel/traverse': 7.13.0
-      '@babel/types': 7.13.0
+      '@babel/helper-member-expression-to-functions': 7.14.7
+      '@babel/helper-optimise-call-expression': 7.14.5
+      '@babel/traverse': 7.14.7
+      '@babel/types': 7.14.5
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -380,13 +999,13 @@ packages:
   /@babel/helper-simple-access/7.12.13:
     resolution: {integrity: sha512-0ski5dyYIHEfwpWGx5GPWhH35j342JaflmCeQmsPWcrOQDtCN6C1zKAVRFVbK53lPW2c9TsuLLSUDf0tIGJ5hA==}
     dependencies:
-      '@babel/types': 7.13.0
+      '@babel/types': 7.14.5
     dev: true
 
   /@babel/helper-skip-transparent-expression-wrappers/7.12.1:
     resolution: {integrity: sha512-Mf5AUuhG1/OCChOJ/HcADmvcHM42WJockombn8ATJG3OnyiSxBK/Mm5x78BQWvmtXZKHgbjdGL2kin/HOLlZGA==}
     dependencies:
-      '@babel/types': 7.13.0
+      '@babel/types': 7.14.5
     dev: true
 
   /@babel/helper-split-export-declaration/7.12.13:
@@ -395,20 +1014,33 @@ packages:
       '@babel/types': 7.13.0
     dev: true
 
+  /@babel/helper-split-export-declaration/7.14.5:
+    resolution: {integrity: sha512-hprxVPu6e5Kdp2puZUmvOGjaLv9TCe58E/Fl6hRq4YiVQxIcNvuq6uTM2r1mT/oPskuS9CgR+I94sqAYv0NGKA==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/types': 7.14.5
+    dev: true
+
   /@babel/helper-validator-identifier/7.12.11:
     resolution: {integrity: sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw==}
 
-  /@babel/helper-validator-option/7.12.17:
-    resolution: {integrity: sha512-TopkMDmLzq8ngChwRlyjR6raKD6gMSae4JdYDB8bByKreQgG0RBTuKe9LRxW3wFtUnjxOPRKBDwEH6Mg5KeDfw==}
+  /@babel/helper-validator-identifier/7.14.5:
+    resolution: {integrity: sha512-5lsetuxCLilmVGyiLEfoHBRX8UCFD+1m2x3Rj97WrW3V7H3u4RWRXA4evMjImCsin2J2YT0QaVDGf+z8ondbAg==}
+    engines: {node: '>=6.9.0'}
+    dev: true
+
+  /@babel/helper-validator-option/7.14.5:
+    resolution: {integrity: sha512-OX8D5eeX4XwcroVW45NMvoYaIuFI+GQpA2a8Gi+X/U/cDUIRsV37qQfF905F0htTRCREQIB4KqPeaveRJUl3Ow==}
+    engines: {node: '>=6.9.0'}
     dev: true
 
   /@babel/helper-wrap-function/7.12.13:
     resolution: {integrity: sha512-t0aZFEmBJ1LojdtJnhOaQEVejnzYhyjWHSsNSNo8vOYRbAJNh6r6GQF7pd36SqG7OKGbn+AewVQ/0IfYfIuGdw==}
     dependencies:
-      '@babel/helper-function-name': 7.12.13
-      '@babel/template': 7.12.13
-      '@babel/traverse': 7.13.0
-      '@babel/types': 7.13.0
+      '@babel/helper-function-name': 7.14.5
+      '@babel/template': 7.14.5
+      '@babel/traverse': 7.14.7
+      '@babel/types': 7.14.5
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -416,9 +1048,9 @@ packages:
   /@babel/helpers/7.12.13:
     resolution: {integrity: sha512-oohVzLRZ3GQEk4Cjhfs9YkJA4TdIDTObdBEZGrd6F/T0GPSnuV6l22eMcxlvcvzVIPH3VTtxbseudM1zIE+rPQ==}
     dependencies:
-      '@babel/template': 7.12.13
-      '@babel/traverse': 7.13.0
-      '@babel/types': 7.13.0
+      '@babel/template': 7.14.5
+      '@babel/traverse': 7.14.7
+      '@babel/types': 7.14.5
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -430,8 +1062,23 @@ packages:
       chalk: 2.4.2
       js-tokens: 4.0.0
 
+  /@babel/highlight/7.14.5:
+    resolution: {integrity: sha512-qf9u2WFWVV0MppaL877j2dBtQIDgmidgjGk5VIMw3OadXvYaXn66U1BFlH2t4+t3i+8PhedppRv+i40ABzd+gg==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/helper-validator-identifier': 7.14.5
+      chalk: 2.4.2
+      js-tokens: 4.0.0
+    dev: true
+
   /@babel/parser/7.13.9:
     resolution: {integrity: sha512-nEUfRiARCcaVo3ny3ZQjURjHQZUo/JkEw7rLlSZy/psWGnvwXFtPcr6jb7Yb41DVW5LTe6KRq9LGleRNsg1Frw==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+    dev: true
+
+  /@babel/parser/7.14.7:
+    resolution: {integrity: sha512-X67Z5y+VBJuHB/RjwECp8kSl5uYi0BvRbNeWqkaJCVh+LiTPl19WBUfG627psSgp9rSf6ojuXghQM3ha6qHHdA==}
     engines: {node: '>=6.0.0'}
     hasBin: true
     dev: true
@@ -442,7 +1089,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.16
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-plugin-utils': 7.14.5
       '@babel/helper-remap-async-to-generator': 7.12.13
       '@babel/plugin-syntax-async-generators': 7.8.4_@babel+core@7.12.16
     transitivePeerDependencies:
@@ -455,8 +1102,8 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.16
-      '@babel/helper-create-class-features-plugin': 7.13.8_@babel+core@7.12.16
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-create-class-features-plugin': 7.14.6_@babel+core@7.12.16
+      '@babel/helper-plugin-utils': 7.14.5
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -467,7 +1114,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.16
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-plugin-utils': 7.14.5
       '@babel/plugin-syntax-dynamic-import': 7.8.3_@babel+core@7.12.16
     dev: true
 
@@ -477,7 +1124,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.16
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-plugin-utils': 7.14.5
       '@babel/plugin-syntax-export-namespace-from': 7.8.3_@babel+core@7.12.16
     dev: true
 
@@ -487,7 +1134,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.16
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-plugin-utils': 7.14.5
       '@babel/plugin-syntax-json-strings': 7.8.3_@babel+core@7.12.16
     dev: true
 
@@ -497,7 +1144,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.16
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-plugin-utils': 7.14.5
       '@babel/plugin-syntax-logical-assignment-operators': 7.10.4_@babel+core@7.12.16
     dev: true
 
@@ -507,7 +1154,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.16
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-plugin-utils': 7.14.5
       '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3_@babel+core@7.12.16
     dev: true
 
@@ -517,7 +1164,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.16
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-plugin-utils': 7.14.5
       '@babel/plugin-syntax-numeric-separator': 7.10.4_@babel+core@7.12.16
     dev: true
 
@@ -527,7 +1174,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.16
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-plugin-utils': 7.14.5
       '@babel/plugin-syntax-object-rest-spread': 7.8.3_@babel+core@7.12.16
       '@babel/plugin-transform-parameters': 7.12.13_@babel+core@7.12.16
     dev: true
@@ -538,7 +1185,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.16
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-plugin-utils': 7.14.5
       '@babel/plugin-syntax-optional-catch-binding': 7.8.3_@babel+core@7.12.16
     dev: true
 
@@ -548,7 +1195,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.16
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-plugin-utils': 7.14.5
       '@babel/helper-skip-transparent-expression-wrappers': 7.12.1
       '@babel/plugin-syntax-optional-chaining': 7.8.3_@babel+core@7.12.16
     dev: true
@@ -559,8 +1206,8 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.16
-      '@babel/helper-create-class-features-plugin': 7.13.8_@babel+core@7.12.16
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-create-class-features-plugin': 7.14.6_@babel+core@7.12.16
+      '@babel/helper-plugin-utils': 7.14.5
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -573,7 +1220,7 @@ packages:
     dependencies:
       '@babel/core': 7.12.16
       '@babel/helper-create-regexp-features-plugin': 7.12.16_@babel+core@7.12.16
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-plugin-utils': 7.14.5
     dev: true
 
   /@babel/plugin-syntax-async-generators/7.8.4_@babel+core@7.12.16:
@@ -582,7 +1229,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.16
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-plugin-utils': 7.14.5
     dev: true
 
   /@babel/plugin-syntax-bigint/7.8.3_@babel+core@7.12.16:
@@ -591,7 +1238,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.16
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-plugin-utils': 7.14.5
     dev: true
 
   /@babel/plugin-syntax-class-properties/7.12.13_@babel+core@7.12.16:
@@ -600,7 +1247,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.16
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-plugin-utils': 7.14.5
     dev: true
 
   /@babel/plugin-syntax-dynamic-import/7.8.3_@babel+core@7.12.16:
@@ -609,7 +1256,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.16
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-plugin-utils': 7.14.5
     dev: true
 
   /@babel/plugin-syntax-export-namespace-from/7.8.3_@babel+core@7.12.16:
@@ -618,7 +1265,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.16
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-plugin-utils': 7.14.5
     dev: true
 
   /@babel/plugin-syntax-import-meta/7.10.4_@babel+core@7.12.16:
@@ -627,7 +1274,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.16
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-plugin-utils': 7.14.5
     dev: true
 
   /@babel/plugin-syntax-json-strings/7.8.3_@babel+core@7.12.16:
@@ -636,7 +1283,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.16
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-plugin-utils': 7.14.5
     dev: true
 
   /@babel/plugin-syntax-jsx/7.12.13_@babel+core@7.12.16:
@@ -654,7 +1301,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.16
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-plugin-utils': 7.14.5
     dev: true
 
   /@babel/plugin-syntax-nullish-coalescing-operator/7.8.3_@babel+core@7.12.16:
@@ -663,7 +1310,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.16
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-plugin-utils': 7.14.5
     dev: true
 
   /@babel/plugin-syntax-numeric-separator/7.10.4_@babel+core@7.12.16:
@@ -672,7 +1319,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.16
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-plugin-utils': 7.14.5
     dev: true
 
   /@babel/plugin-syntax-object-rest-spread/7.8.3_@babel+core@7.12.16:
@@ -681,7 +1328,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.16
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-plugin-utils': 7.14.5
     dev: true
 
   /@babel/plugin-syntax-optional-catch-binding/7.8.3_@babel+core@7.12.16:
@@ -690,7 +1337,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.16
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-plugin-utils': 7.14.5
     dev: true
 
   /@babel/plugin-syntax-optional-chaining/7.8.3_@babel+core@7.12.16:
@@ -699,7 +1346,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.16
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-plugin-utils': 7.14.5
     dev: true
 
   /@babel/plugin-syntax-top-level-await/7.12.13_@babel+core@7.12.16:
@@ -708,7 +1355,17 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.16
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-plugin-utils': 7.14.5
+    dev: true
+
+  /@babel/plugin-syntax-typescript/7.14.5_@babel+core@7.12.16:
+    resolution: {integrity: sha512-u6OXzDaIXjEstBRRoBCQ/uKQKlbuaeE5in0RvWdA4pN6AhqxTIwUsnHPU1CFZA/amYObMsuWhYfRl3Ch90HD0Q==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.12.16
+      '@babel/helper-plugin-utils': 7.14.5
     dev: true
 
   /@babel/plugin-transform-arrow-functions/7.12.13_@babel+core@7.12.16:
@@ -717,7 +1374,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.16
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-plugin-utils': 7.14.5
     dev: true
 
   /@babel/plugin-transform-async-to-generator/7.12.13_@babel+core@7.12.16:
@@ -727,7 +1384,7 @@ packages:
     dependencies:
       '@babel/core': 7.12.16
       '@babel/helper-module-imports': 7.12.13
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-plugin-utils': 7.14.5
       '@babel/helper-remap-async-to-generator': 7.12.13
     transitivePeerDependencies:
       - supports-color
@@ -739,7 +1396,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.16
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-plugin-utils': 7.14.5
     dev: true
 
   /@babel/plugin-transform-block-scoping/7.12.13_@babel+core@7.12.16:
@@ -748,7 +1405,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.16
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-plugin-utils': 7.14.5
     dev: true
 
   /@babel/plugin-transform-classes/7.12.13_@babel+core@7.12.16:
@@ -757,12 +1414,12 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.16
-      '@babel/helper-annotate-as-pure': 7.12.13
-      '@babel/helper-function-name': 7.12.13
-      '@babel/helper-optimise-call-expression': 7.12.13
-      '@babel/helper-plugin-utils': 7.13.0
-      '@babel/helper-replace-supers': 7.13.0
-      '@babel/helper-split-export-declaration': 7.12.13
+      '@babel/helper-annotate-as-pure': 7.14.5
+      '@babel/helper-function-name': 7.14.5
+      '@babel/helper-optimise-call-expression': 7.14.5
+      '@babel/helper-plugin-utils': 7.14.5
+      '@babel/helper-replace-supers': 7.14.5
+      '@babel/helper-split-export-declaration': 7.14.5
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
@@ -774,7 +1431,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.16
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-plugin-utils': 7.14.5
     dev: true
 
   /@babel/plugin-transform-destructuring/7.12.13_@babel+core@7.12.16:
@@ -783,7 +1440,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.16
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-plugin-utils': 7.14.5
     dev: true
 
   /@babel/plugin-transform-dotall-regex/7.12.13_@babel+core@7.12.16:
@@ -793,7 +1450,7 @@ packages:
     dependencies:
       '@babel/core': 7.12.16
       '@babel/helper-create-regexp-features-plugin': 7.12.16_@babel+core@7.12.16
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-plugin-utils': 7.14.5
     dev: true
 
   /@babel/plugin-transform-duplicate-keys/7.12.13_@babel+core@7.12.16:
@@ -802,7 +1459,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.16
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-plugin-utils': 7.14.5
     dev: true
 
   /@babel/plugin-transform-exponentiation-operator/7.12.13_@babel+core@7.12.16:
@@ -812,7 +1469,7 @@ packages:
     dependencies:
       '@babel/core': 7.12.16
       '@babel/helper-builder-binary-assignment-operator-visitor': 7.12.13
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-plugin-utils': 7.14.5
     dev: true
 
   /@babel/plugin-transform-for-of/7.12.13_@babel+core@7.12.16:
@@ -821,7 +1478,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.16
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-plugin-utils': 7.14.5
     dev: true
 
   /@babel/plugin-transform-function-name/7.12.13_@babel+core@7.12.16:
@@ -830,8 +1487,8 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.16
-      '@babel/helper-function-name': 7.12.13
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-function-name': 7.14.5
+      '@babel/helper-plugin-utils': 7.14.5
     dev: true
 
   /@babel/plugin-transform-literals/7.12.13_@babel+core@7.12.16:
@@ -840,7 +1497,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.16
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-plugin-utils': 7.14.5
     dev: true
 
   /@babel/plugin-transform-member-expression-literals/7.12.13_@babel+core@7.12.16:
@@ -849,7 +1506,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.16
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-plugin-utils': 7.14.5
     dev: true
 
   /@babel/plugin-transform-modules-amd/7.12.13_@babel+core@7.12.16:
@@ -859,7 +1516,7 @@ packages:
     dependencies:
       '@babel/core': 7.12.16
       '@babel/helper-module-transforms': 7.12.13
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-plugin-utils': 7.14.5
       babel-plugin-dynamic-import-node: 2.3.3
     transitivePeerDependencies:
       - supports-color
@@ -872,7 +1529,7 @@ packages:
     dependencies:
       '@babel/core': 7.12.16
       '@babel/helper-module-transforms': 7.12.13
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-plugin-utils': 7.14.5
       '@babel/helper-simple-access': 7.12.13
       babel-plugin-dynamic-import-node: 2.3.3
     transitivePeerDependencies:
@@ -885,10 +1542,10 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.16
-      '@babel/helper-hoist-variables': 7.12.13
+      '@babel/helper-hoist-variables': 7.14.5
       '@babel/helper-module-transforms': 7.12.13
-      '@babel/helper-plugin-utils': 7.13.0
-      '@babel/helper-validator-identifier': 7.12.11
+      '@babel/helper-plugin-utils': 7.14.5
+      '@babel/helper-validator-identifier': 7.14.5
       babel-plugin-dynamic-import-node: 2.3.3
     transitivePeerDependencies:
       - supports-color
@@ -901,7 +1558,7 @@ packages:
     dependencies:
       '@babel/core': 7.12.16
       '@babel/helper-module-transforms': 7.12.13
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-plugin-utils': 7.14.5
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -921,7 +1578,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.16
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-plugin-utils': 7.14.5
     dev: true
 
   /@babel/plugin-transform-object-super/7.12.13_@babel+core@7.12.16:
@@ -930,8 +1587,8 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.16
-      '@babel/helper-plugin-utils': 7.13.0
-      '@babel/helper-replace-supers': 7.13.0
+      '@babel/helper-plugin-utils': 7.14.5
+      '@babel/helper-replace-supers': 7.14.5
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -942,7 +1599,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.16
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-plugin-utils': 7.14.5
     dev: true
 
   /@babel/plugin-transform-property-literals/7.12.13_@babel+core@7.12.16:
@@ -951,7 +1608,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.16
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-plugin-utils': 7.14.5
     dev: true
 
   /@babel/plugin-transform-react-display-name/7.12.13_@babel+core@7.12.16:
@@ -1010,7 +1667,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.16
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-plugin-utils': 7.14.5
     dev: true
 
   /@babel/plugin-transform-runtime/7.12.15_@babel+core@7.12.16:
@@ -1020,7 +1677,7 @@ packages:
     dependencies:
       '@babel/core': 7.12.16
       '@babel/helper-module-imports': 7.12.13
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-plugin-utils': 7.14.5
       semver: 5.7.1
     dev: true
 
@@ -1030,7 +1687,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.16
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-plugin-utils': 7.14.5
     dev: true
 
   /@babel/plugin-transform-spread/7.12.13_@babel+core@7.12.16:
@@ -1039,7 +1696,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.16
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-plugin-utils': 7.14.5
       '@babel/helper-skip-transparent-expression-wrappers': 7.12.1
     dev: true
 
@@ -1049,7 +1706,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.16
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-plugin-utils': 7.14.5
     dev: true
 
   /@babel/plugin-transform-template-literals/7.12.13_@babel+core@7.12.16:
@@ -1058,7 +1715,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.16
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-plugin-utils': 7.14.5
     dev: true
 
   /@babel/plugin-transform-typeof-symbol/7.12.13_@babel+core@7.12.16:
@@ -1067,7 +1724,21 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.16
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-plugin-utils': 7.14.5
+    dev: true
+
+  /@babel/plugin-transform-typescript/7.14.6_@babel+core@7.12.16:
+    resolution: {integrity: sha512-XlTdBq7Awr4FYIzqhmYY80WN0V0azF74DMPyFqVHBvf81ZUgc4X7ZOpx6O8eLDK6iM5cCQzeyJw0ynTaefixRA==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.12.16
+      '@babel/helper-create-class-features-plugin': 7.14.6_@babel+core@7.12.16
+      '@babel/helper-plugin-utils': 7.14.5
+      '@babel/plugin-syntax-typescript': 7.14.5_@babel+core@7.12.16
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
   /@babel/plugin-transform-unicode-escapes/7.12.13_@babel+core@7.12.16:
@@ -1076,7 +1747,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.16
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-plugin-utils': 7.14.5
     dev: true
 
   /@babel/plugin-transform-unicode-regex/7.12.13_@babel+core@7.12.16:
@@ -1086,7 +1757,7 @@ packages:
     dependencies:
       '@babel/core': 7.12.16
       '@babel/helper-create-regexp-features-plugin': 7.12.16_@babel+core@7.12.16
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-plugin-utils': 7.14.5
     dev: true
 
   /@babel/preset-env/7.12.16_@babel+core@7.12.16:
@@ -1098,8 +1769,8 @@ packages:
       '@babel/core': 7.12.16
       '@babel/helper-compilation-targets': 7.12.16_@babel+core@7.12.16
       '@babel/helper-module-imports': 7.12.13
-      '@babel/helper-plugin-utils': 7.13.0
-      '@babel/helper-validator-option': 7.12.17
+      '@babel/helper-plugin-utils': 7.14.5
+      '@babel/helper-validator-option': 7.14.5
       '@babel/plugin-proposal-async-generator-functions': 7.12.13_@babel+core@7.12.16
       '@babel/plugin-proposal-class-properties': 7.12.13_@babel+core@7.12.16
       '@babel/plugin-proposal-dynamic-import': 7.12.16_@babel+core@7.12.16
@@ -1158,7 +1829,7 @@ packages:
       '@babel/plugin-transform-unicode-escapes': 7.12.13_@babel+core@7.12.16
       '@babel/plugin-transform-unicode-regex': 7.12.13_@babel+core@7.12.16
       '@babel/preset-modules': 0.1.4_@babel+core@7.12.16
-      '@babel/types': 7.13.0
+      '@babel/types': 7.14.5
       core-js-compat: 3.8.3
       semver: 5.7.1
     transitivePeerDependencies:
@@ -1171,10 +1842,10 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.16
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-plugin-utils': 7.14.5
       '@babel/plugin-proposal-unicode-property-regex': 7.12.13_@babel+core@7.12.16
       '@babel/plugin-transform-dotall-regex': 7.12.13_@babel+core@7.12.16
-      '@babel/types': 7.13.0
+      '@babel/types': 7.14.5
       esutils: 2.0.3
     dev: true
 
@@ -1189,6 +1860,20 @@ packages:
       '@babel/plugin-transform-react-jsx': 7.12.16_@babel+core@7.12.16
       '@babel/plugin-transform-react-jsx-development': 7.12.16_@babel+core@7.12.16
       '@babel/plugin-transform-react-pure-annotations': 7.12.1_@babel+core@7.12.16
+    dev: true
+
+  /@babel/preset-typescript/7.14.5_@babel+core@7.12.16:
+    resolution: {integrity: sha512-u4zO6CdbRKbS9TypMqrlGH7sd2TAJppZwn3c/ZRLeO/wGsbddxgbPDUZVNrie3JWYLQ9vpineKlsrWFvO6Pwkw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.12.16
+      '@babel/helper-plugin-utils': 7.14.5
+      '@babel/helper-validator-option': 7.14.5
+      '@babel/plugin-transform-typescript': 7.14.6_@babel+core@7.12.16
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
   /@babel/runtime-corejs3/7.12.13:
@@ -1212,6 +1897,15 @@ packages:
       '@babel/types': 7.13.0
     dev: true
 
+  /@babel/template/7.14.5:
+    resolution: {integrity: sha512-6Z3Po85sfxRGachLULUhOmvAaOo7xCvqGQtxINai2mEGPFm6pQ4z5QInFnUrRpfoSV60BnjyF5F3c+15fxFV1g==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/code-frame': 7.14.5
+      '@babel/parser': 7.14.7
+      '@babel/types': 7.14.5
+    dev: true
+
   /@babel/traverse/7.13.0:
     resolution: {integrity: sha512-xys5xi5JEhzC3RzEmSGrs/b3pJW/o87SypZ+G/PhaE7uqVQNv/jlmVIBXuoh5atqQ434LfXV+sf23Oxj0bchJQ==}
     dependencies:
@@ -1228,11 +1922,36 @@ packages:
       - supports-color
     dev: true
 
+  /@babel/traverse/7.14.7:
+    resolution: {integrity: sha512-9vDr5NzHu27wgwejuKL7kIOm4bwEtaPQ4Z6cpCmjSuaRqpH/7xc4qcGEscwMqlkwgcXl6MvqoAjZkQ24uSdIZQ==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/code-frame': 7.14.5
+      '@babel/generator': 7.14.5
+      '@babel/helper-function-name': 7.14.5
+      '@babel/helper-hoist-variables': 7.14.5
+      '@babel/helper-split-export-declaration': 7.14.5
+      '@babel/parser': 7.14.7
+      '@babel/types': 7.14.5
+      debug: 4.3.1
+      globals: 11.12.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /@babel/types/7.13.0:
     resolution: {integrity: sha512-hE+HE8rnG1Z6Wzo+MhaKE5lM5eMx71T4EHJgku2E3xIfaULhDcxiiRxUYgwX8qwP1BBSlag+TdGOt6JAidIZTA==}
     dependencies:
       '@babel/helper-validator-identifier': 7.12.11
       lodash: 4.17.20
+      to-fast-properties: 2.0.0
+    dev: true
+
+  /@babel/types/7.14.5:
+    resolution: {integrity: sha512-M/NzBpEL95I5Hh4dwhin5JlE7EzO5PHMAuzjxss3tiOBD46KfQvVedN/3jEPZvdRvtsK2222XfdHogNIttFgcg==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/helper-validator-identifier': 7.14.5
       to-fast-properties: 2.0.0
     dev: true
 
@@ -1454,7 +2173,7 @@ packages:
       ignore: 4.0.6
       import-fresh: 3.3.0
       js-yaml: 3.14.1
-      lodash: 4.17.20
+      lodash: 4.17.21
       minimatch: 3.0.4
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
@@ -1662,7 +2381,6 @@ packages:
       '@types/node': 14.14.31
       '@types/yargs': 15.0.13
       chalk: 4.1.0
-    dev: true
 
   /@manypkg/find-root/1.1.0:
     resolution: {integrity: sha512-mki5uBvhHzO8kYYix/WRy2WX8S3B5wdVSc9D6KcU5lQNglP2yt58/VfLuAK49glRXChosY8ap2oJ1qgma3GUVA==}
@@ -1719,6 +2437,53 @@ packages:
     resolution: {integrity: sha512-3NsZsJIA/22P3QUyrEDNA2D133H4j224twJrdipXN38dpnIOzAbUDtOwkcJ5pXmn75w7LSQDjA4tO9dm1XlqlA==}
     dev: false
 
+  /@polka/url/1.0.0-next.15:
+    resolution: {integrity: sha512-15spi3V28QdevleWBNXE4pIls3nFZmBbUGrW9IVPwiQczuSb9n76TCB4bsk8TSel+I1OkHEdPhu5QKMfY6rQHA==}
+    dev: false
+
+  /@rollup/plugin-commonjs/17.1.0_rollup@2.52.3:
+    resolution: {integrity: sha512-PoMdXCw0ZyvjpCMT5aV4nkL0QywxP29sODQsSGeDpr/oI49Qq9tRtAsb/LbYbDzFlOydVEqHmmZWFtXJEAX9ew==}
+    engines: {node: '>= 8.0.0'}
+    peerDependencies:
+      rollup: ^2.30.0
+    dependencies:
+      '@rollup/pluginutils': 3.1.0_rollup@2.52.3
+      commondir: 1.0.1
+      estree-walker: 2.0.2
+      glob: 7.1.6
+      is-reference: 1.2.1
+      magic-string: 0.25.7
+      resolve: 1.20.0
+      rollup: 2.52.3
+    dev: true
+
+  /@rollup/plugin-node-resolve/11.2.1_rollup@2.52.3:
+    resolution: {integrity: sha512-yc2n43jcqVyGE2sqV5/YCmocy9ArjVAP/BeXyTtADTBBX6V0e5UMqwO8CdQ0kzjb6zu5P1qMzsScCMRvE9OlVg==}
+    engines: {node: '>= 10.0.0'}
+    peerDependencies:
+      rollup: ^1.20.0||^2.0.0
+    dependencies:
+      '@rollup/pluginutils': 3.1.0_rollup@2.52.3
+      '@types/resolve': 1.17.1
+      builtin-modules: 3.2.0
+      deepmerge: 4.2.2
+      is-module: 1.0.0
+      resolve: 1.20.0
+      rollup: 2.52.3
+    dev: true
+
+  /@rollup/pluginutils/3.1.0_rollup@2.52.3:
+    resolution: {integrity: sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==}
+    engines: {node: '>= 8.0.0'}
+    peerDependencies:
+      rollup: ^1.20.0||^2.0.0
+    dependencies:
+      '@types/estree': 0.0.39
+      estree-walker: 1.0.1
+      picomatch: 2.2.2
+      rollup: 2.52.3
+    dev: true
+
   /@sinonjs/commons/1.8.2:
     resolution: {integrity: sha512-sruwd86RJHdsVf/AtBoijDmUqJp3B6hF/DGC23C+JaegnDHaZyewCjoVGTdg3J0uz3Zs7NnIT05OBOmML72lQw==}
     dependencies:
@@ -1767,7 +2532,7 @@ packages:
       chalk: 3.0.0
       css: 3.0.0
       css.escape: 1.5.1
-      lodash: 4.17.20
+      lodash: 4.17.21
       redent: 3.0.0
     dev: true
 
@@ -1784,6 +2549,16 @@ packages:
       react-dom: 17.0.1_react@17.0.1
     dev: true
 
+  /@testing-library/svelte/3.0.3_svelte@3.38.3:
+    resolution: {integrity: sha512-GxafAllShGM2nkntFGURZ7fYVlUYwv7K62lqv1aFqtTYzzeZ2Cu8zTVhtE/Qt3bk2zMl6+FPKP03wjLip/G8mA==}
+    engines: {node: '>= 8'}
+    peerDependencies:
+      svelte: 3.x
+    dependencies:
+      '@testing-library/dom': 7.29.4
+      svelte: 3.38.3
+    dev: true
+
   /@types/aria-query/4.2.1:
     resolution: {integrity: sha512-S6oPal772qJZHoRZLFc/XoZW2gFvwXusYUmXPXkgxJLuEk2vOt7jc4Yo6z/vtI0EBkbPBVrJJ0B+prLIKiWqHg==}
     dev: true
@@ -1791,8 +2566,8 @@ packages:
   /@types/babel__core/7.1.12:
     resolution: {integrity: sha512-wMTHiiTiBAAPebqaPiPDLFA4LYPKr6Ph0Xq/6rq1Ur3v66HXyG+clfR9CNETkD7MQS8ZHvpQOtA53DLws5WAEQ==}
     dependencies:
-      '@babel/parser': 7.13.9
-      '@babel/types': 7.13.0
+      '@babel/parser': 7.14.7
+      '@babel/types': 7.14.5
       '@types/babel__generator': 7.6.2
       '@types/babel__template': 7.4.0
       '@types/babel__traverse': 7.11.0
@@ -1801,20 +2576,20 @@ packages:
   /@types/babel__generator/7.6.2:
     resolution: {integrity: sha512-MdSJnBjl+bdwkLskZ3NGFp9YcXGx5ggLpQQPqtgakVhsWK0hTtNYhjpZLlWQTviGTvF8at+Bvli3jV7faPdgeQ==}
     dependencies:
-      '@babel/types': 7.13.0
+      '@babel/types': 7.14.5
     dev: true
 
   /@types/babel__template/7.4.0:
     resolution: {integrity: sha512-NTPErx4/FiPCGScH7foPyr+/1Dkzkni+rHiYHHoTjvwou7AQzJkNeD60A9CXRy+ZEN2B1bggmkTMCDb+Mv5k+A==}
     dependencies:
-      '@babel/parser': 7.13.9
-      '@babel/types': 7.13.0
+      '@babel/parser': 7.14.7
+      '@babel/types': 7.14.5
     dev: true
 
   /@types/babel__traverse/7.11.0:
     resolution: {integrity: sha512-kSjgDMZONiIfSH1Nxcr5JIRMwUetDki63FSQfpTCz8ogF3Ulqm8+mr5f78dUYs6vMiB6gBusQqfQmBvHZj/lwg==}
     dependencies:
-      '@babel/types': 7.13.0
+      '@babel/types': 7.14.5
     dev: true
 
   /@types/eslint-scope/3.7.0:
@@ -1829,6 +2604,10 @@ packages:
     dependencies:
       '@types/estree': 0.0.46
       '@types/json-schema': 7.0.7
+    dev: true
+
+  /@types/estree/0.0.39:
+    resolution: {integrity: sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==}
     dev: true
 
   /@types/estree/0.0.46:
@@ -1849,7 +2628,6 @@ packages:
 
   /@types/html-minifier-terser/5.1.1:
     resolution: {integrity: sha512-giAlZwstKbmvMk1OO7WXSj4OZ0keXAcl2TQq4LWHiiPH2ByaH7WeUzng+Qej8UPxxv+8lRTuouo0iaNDBuzIBA==}
-    dev: false
 
   /@types/http-proxy/1.17.5:
     resolution: {integrity: sha512-GNkDE7bTv6Sf8JbV2GksknKOsk7OznNYHSdrtvPJXO0qJ9odZig6IZKUi5RFGi6d1bf6dgIAe4uXi3DBc7069Q==}
@@ -1859,26 +2637,22 @@ packages:
 
   /@types/istanbul-lib-coverage/2.0.3:
     resolution: {integrity: sha512-sz7iLqvVUg1gIedBOvlkxPlc8/uVzyS5OwGz1cKjXzkl3FpL3al0crU8YGU1WoHkxn0Wxbw5tyi6hvzJKNzFsw==}
-    dev: true
 
   /@types/istanbul-lib-report/3.0.0:
     resolution: {integrity: sha512-plGgXAPfVKFoYfa9NpYDAkseG+g6Jr294RqeqcqDixSbU34MZVJRi/P+7Y8GDpzkEwLaGZZOpKIEmeVZNtKsrg==}
     dependencies:
       '@types/istanbul-lib-coverage': 2.0.3
-    dev: true
 
   /@types/istanbul-reports/3.0.0:
     resolution: {integrity: sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==}
     dependencies:
       '@types/istanbul-lib-report': 3.0.0
-    dev: true
 
   /@types/jest/26.0.20:
     resolution: {integrity: sha512-9zi2Y+5USJRxd0FsahERhBwlcvFh6D2GLQnY2FH2BzK8J9s9omvNHIbvABwIluXa0fD8XVKMLTO0aOEuUfACAA==}
     dependencies:
       jest-diff: 26.6.2
       pretty-format: 26.6.2
-    dev: true
 
   /@types/json-schema/7.0.7:
     resolution: {integrity: sha512-cxWFQVseBm6O9Gbw1IWb8r6OS4OhSt3hPZLkFApLjM8TEXROBuQGLAH2i2gZpcXdLBIrpXuTDhH7Vbm1iXmNGA==}
@@ -1899,7 +2673,6 @@ packages:
 
   /@types/node/14.14.31:
     resolution: {integrity: sha512-vFHy/ezP5qI0rFgJ7aQnjDXwAMrG0KqqIH7tQG5PPv3BWBayOPIQNBjVc/P6hhdZfMx51REc6tfDNXHUio893g==}
-    dev: true
 
   /@types/normalize-package-data/2.4.0:
     resolution: {integrity: sha512-f5j5b/Gf71L+dbqxIpQ4Z2WlmI/mPJ0fOkGGmFgtb6sAu97EPczzbS3/tJKxmcYDj55OX6ssqwDAWOHIYDRDGA==}
@@ -1907,13 +2680,45 @@ packages:
   /@types/parse-json/4.0.0:
     resolution: {integrity: sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==}
 
+  /@types/parse5/5.0.3:
+    resolution: {integrity: sha512-kUNnecmtkunAoQ3CnjmMkzNU/gtxG8guhi+Fk2U/kOpIKjIMKnXGp4IJCgQJrXSgMsWYimYG4TGjz/UzbGEBTw==}
+    dev: false
+
   /@types/prettier/2.2.1:
     resolution: {integrity: sha512-DxZZbyMAM9GWEzXL+BMZROWz9oo6A9EilwwOMET2UVu2uZTqMWS5S69KVtuVKaRjCUpcrOXRalet86/OpG4kqw==}
+    dev: true
+
+  /@types/prop-types/15.7.3:
+    resolution: {integrity: sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw==}
+    dev: false
+
+  /@types/react-dom/16.9.13:
+    resolution: {integrity: sha512-34Hr3XnmUSJbUVDxIw/e7dhQn2BJZhJmlAaPyPwfTQyuVS9mV/CeyghFcXyvkJXxI7notQJz8mF8FeCVvloJrA==}
+    dependencies:
+      '@types/react': 16.14.8
+    dev: false
+
+  /@types/react/16.14.8:
+    resolution: {integrity: sha512-QN0/Qhmx+l4moe7WJuTxNiTsjBwlBGHqKGvInSQCBdo7Qio0VtOqwsC0Wq7q3PbJlB0cR4Y4CVo1OOe6BOsOmA==}
+    dependencies:
+      '@types/prop-types': 15.7.3
+      '@types/scheduler': 0.16.1
+      csstype: 3.0.8
+    dev: false
+
+  /@types/resolve/1.17.1:
+    resolution: {integrity: sha512-yy7HuzQhj0dhGpD8RLXSZWEkLsV9ibvxvi6EiJ3bkqLAO1RGo0WbkWQiwpRlSFymTJRz0d3k5LM3kkx8ArDbLw==}
+    dependencies:
+      '@types/node': 14.14.31
     dev: true
 
   /@types/retry/0.12.0:
     resolution: {integrity: sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==}
     dev: true
+
+  /@types/scheduler/0.16.1:
+    resolution: {integrity: sha512-EaCxbanVeyxDRTQBkdLb3Bvl/HK7PBK6UJjsSixB0iHKoWxE5uu2Q/DgtpOhPIojN0Zl1whvOd7PoHs2P0s5eA==}
+    dev: false
 
   /@types/semver/6.2.2:
     resolution: {integrity: sha512-RxAwYt4rGwK5GyoRwuP0jT6ZHAVTdz2EqgsHmX0PYNjGsko+OeT4WFXXTs/lM3teJUJodM+SNtAL5/pXIJ61IQ==}
@@ -1923,21 +2728,27 @@ packages:
     resolution: {integrity: sha512-RJJrrySY7A8havqpGObOB4W92QXKJo63/jFLLgpvOtsGUqbQZ9Sbgl35KMm1DjC6j7AvmmU2bIno+3IyEaemaw==}
     dev: true
 
+  /@types/systemjs/6.1.0:
+    resolution: {integrity: sha512-akhlviqwowzRNiz3ooAbkjvyMO8cikBqap9z/0yfvMAb6vIsp91Rfox67qtgIhZosWP01MVSTwsgSFYWo4SWQA==}
+    dev: false
+
   /@types/testing-library__jest-dom/5.9.5:
     resolution: {integrity: sha512-ggn3ws+yRbOHog9GxnXiEZ/35Mow6YtPZpd7Z5mKDeZS/o7zx3yAle0ov/wjhVB5QT4N2Dt+GNoGCdqkBGCajQ==}
     dependencies:
       '@types/jest': 26.0.20
     dev: true
 
+  /@types/webpack-env/1.16.0:
+    resolution: {integrity: sha512-Fx+NpfOO0CpeYX2g9bkvX8O5qh9wrU1sOF4g8sft4Mu7z+qfe387YlyY8w8daDyDsKY5vUxM0yxkAYnbkRbZEw==}
+    dev: false
+
   /@types/yargs-parser/20.2.0:
     resolution: {integrity: sha512-37RSHht+gzzgYeobbG+KWryeAW8J33Nhr69cjTqSYymXVZEN9NbRYWoYlRtDhHKPVT1FyNKwaTPC1NynKZpzRA==}
-    dev: true
 
   /@types/yargs/15.0.13:
     resolution: {integrity: sha512-kQ5JNTrbDv3Rp5X2n/iUu37IJBDU2gsZ5R/g1/KHOOEc5IKfUFjXT6DENPGduh08I/pamwtEq4oul7gUqKTQDQ==}
     dependencies:
       '@types/yargs-parser': 20.2.0
-    dev: true
 
   /@webassemblyjs/ast/1.11.0:
     resolution: {integrity: sha512-kX2W49LWsbthrmIRMbQZuQDhGtjyqXfEmmHyEi4XWnSZtPmxY0+3anPIzsnRb45VH/J55zlOfWvZuY47aJZTJg==}
@@ -2085,6 +2896,10 @@ packages:
     resolution: {integrity: sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==}
     dev: true
 
+  /@zeit/schemas/2.6.0:
+    resolution: {integrity: sha512-uUrgZ8AxS+Lio0fZKAipJjAh415JyrOZowliZAzmnJSsf7piVL5w+G0+gFJ0KSu3QRhvui/7zuvpLz03YjXAhg==}
+    dev: true
+
   /JSONStream/1.3.5:
     resolution: {integrity: sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==}
     hasBin: true
@@ -2163,6 +2978,15 @@ packages:
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
 
+  /ajv/6.5.3:
+    resolution: {integrity: sha512-LqZ9wY+fx3UMiiPd741yB2pj3hhil+hQc8taf4o2QGRFpWgZ2V5C8HA165DY9sS3fJwsk7uT7ZlFEyC3Ig3lLg==}
+    dependencies:
+      fast-deep-equal: 2.0.1
+      fast-json-stable-stringify: 2.1.0
+      json-schema-traverse: 0.4.1
+      uri-js: 4.4.1
+    dev: true
+
   /ajv/7.1.0:
     resolution: {integrity: sha512-svS9uILze/cXbH0z2myCK2Brqprx/+JJYK5pHicT/GQiBfzzhUVAIT6MwqJg8y4xV/zoGsUeuPuwtoiKSGE15g==}
     dependencies:
@@ -2198,7 +3022,6 @@ packages:
   /ansi-regex/2.1.1:
     resolution: {integrity: sha1-w7M6te42DYbg5ijwRorn7yfWVN8=}
     engines: {node: '>=0.10.0'}
-    dev: false
 
   /ansi-regex/3.0.0:
     resolution: {integrity: sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=}
@@ -2238,6 +3061,14 @@ packages:
     dependencies:
       normalize-path: 3.0.0
       picomatch: 2.2.2
+
+  /arch/2.2.0:
+    resolution: {integrity: sha512-Of/R0wqp83cgHozfIYLbBMnej79U/SVGOOyuB3VVFv1NRM/PSFMK12x9KVtiYzJqmnU5WR2qp0Z5rHb7sWGnFQ==}
+    dev: true
+
+  /arg/2.0.0:
+    resolution: {integrity: sha512-XxNTUzKnz1ctK3ZIcI2XUPlD96wbHP2nGqkPKpvk/HNRlPveYrXIVSTk9m3LcqOgDPg3B1nMvdV/K8wZd7PG4w==}
+    dev: true
 
   /argparse/1.0.10:
     resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
@@ -2457,7 +3288,7 @@ packages:
     resolution: {integrity: sha512-AF55rZXpe7trmEylbaE1Gv54wn6rwU03aptvRoVIGP8YykoSxqdVLV1TfwflBCE/QtHmqtP8SWlTENqbK8GCSQ==}
     engines: {node: '>=8'}
     dependencies:
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-plugin-utils': 7.14.5
       '@istanbuljs/load-nyc-config': 1.1.0
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-instrument: 4.0.3
@@ -2470,8 +3301,8 @@ packages:
     resolution: {integrity: sha512-PO9t0697lNTmcEHH69mdtYiOIkkOlj9fySqfO3K1eCcdISevLAE0xY59VLLUj0SoiPiTX/JU2CYFpILydUa5Lw==}
     engines: {node: '>= 10.14.2'}
     dependencies:
-      '@babel/template': 7.12.13
-      '@babel/types': 7.13.0
+      '@babel/template': 7.14.5
+      '@babel/types': 7.14.5
       '@types/babel__core': 7.1.12
       '@types/babel__traverse': 7.11.0
     dev: true
@@ -2586,7 +3417,6 @@ packages:
 
   /boolbase/1.0.0:
     resolution: {integrity: sha1-aN/1++YMUes3cl6p4+0xDcwed24=}
-    dev: false
 
   /boxen/1.3.0:
     resolution: {integrity: sha512-TNPjfTr432qx7yOjQyaXm3dSR0MH9vXp7eT1BFSl/C51g+EFnOR9hTg1IreahGBmDNCehscshe45f+C1TBZbLw==}
@@ -2663,6 +3493,11 @@ packages:
     resolution: {integrity: sha512-4/rOEg86jivtPTeOUUT61jJO1Ya1TrR/OkqCSZDyq84WJh3LuuiphBYJN+fm5xufIk4XAFcEwte/8WzC8If/1g==}
     dev: true
 
+  /builtin-modules/3.2.0:
+    resolution: {integrity: sha512-lGzLKcioL90C7wMczpkY0n/oART3MbBa8R9OFGE1rJxoVI86u4WAGfEk8Wjv10eKSyTHVGkSo3bvBylCEtk7LA==}
+    engines: {node: '>=6'}
+    dev: true
+
   /bytes/3.0.0:
     resolution: {integrity: sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg=}
     engines: {node: '>= 0.8'}
@@ -2705,7 +3540,6 @@ packages:
     dependencies:
       pascal-case: 3.1.2
       tslib: 2.1.0
-    dev: false
 
   /camelcase-keys/6.2.2:
     resolution: {integrity: sha512-YrwaA0vEKazPBkn0ipTiMpSajYDSe+KjQfrjhcBMxJt/znbvlHd8Pw/Vamaz5EB4Wfhs3SUR3Z9mwRu/P3s3Yg==}
@@ -2746,6 +3580,15 @@ packages:
 
   /caseless/0.12.0:
     resolution: {integrity: sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=}
+    dev: true
+
+  /chalk/2.4.1:
+    resolution: {integrity: sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==}
+    engines: {node: '>=4'}
+    dependencies:
+      ansi-styles: 3.2.1
+      escape-string-regexp: 1.0.5
+      supports-color: 5.5.0
     dev: true
 
   /chalk/2.4.2:
@@ -2822,7 +3665,6 @@ packages:
     engines: {node: '>= 4.0'}
     dependencies:
       source-map: 0.6.1
-    dev: false
 
   /clean-stack/2.2.0:
     resolution: {integrity: sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==}
@@ -2850,6 +3692,14 @@ packages:
   /cli-width/3.0.0:
     resolution: {integrity: sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw==}
     engines: {node: '>= 10'}
+
+  /clipboardy/1.2.3:
+    resolution: {integrity: sha512-2WNImOvCRe6r63Gk9pShfkwXsVtKCroMAevIbiae021mS850UkWPbevxsBz3tnvjZIEGvlwaqCPsw+4ulzNgJA==}
+    engines: {node: '>=4'}
+    dependencies:
+      arch: 2.2.0
+      execa: 0.8.0
+    dev: true
 
   /cliui/5.0.0:
     resolution: {integrity: sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==}
@@ -2958,7 +3808,6 @@ packages:
   /commander/4.1.1:
     resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
     engines: {node: '>= 6'}
-    dev: false
 
   /commander/6.2.1:
     resolution: {integrity: sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==}
@@ -2987,6 +3836,19 @@ packages:
       mime-db: 1.46.0
     dev: true
 
+  /compression/1.7.3:
+    resolution: {integrity: sha512-HSjyBG5N1Nnz7tF2+O7A9XUhyjru71/fwgNb7oIsEVHR0WShfs2tIS/EySLgiTe98aOK18YDlMXpzjCXY/n9mg==}
+    engines: {node: '>= 0.8.0'}
+    dependencies:
+      accepts: 1.3.7
+      bytes: 3.0.0
+      compressible: 2.0.18
+      debug: 2.6.9
+      on-headers: 1.0.2
+      safe-buffer: 5.1.2
+      vary: 1.1.2
+    dev: true
+
   /compression/1.7.4:
     resolution: {integrity: sha512-jaSIDzP9pZVS4ZfQ+TzvtiWhdpFhE2RDHz8QJkpX9SIpLq88VueF5jJw6t+6CUQcAoA6t+x89MLrWAqpfDE8iQ==}
     engines: {node: '>= 0.8.0'}
@@ -3010,7 +3872,7 @@ packages:
     dependencies:
       chalk: 2.4.2
       date-fns: 2.17.0
-      lodash: 4.17.20
+      lodash: 4.17.21
       read-pkg: 4.0.1
       rxjs: 6.6.3
       spawn-command: 0.0.2-1
@@ -3022,6 +3884,16 @@ packages:
   /connect-history-api-fallback/1.6.0:
     resolution: {integrity: sha512-e54B99q/OUoH64zYYRf3HBP5z24G38h5D3qXu23JGRoigpX5Ss4r9ZnDk3g0Z8uQC2x2lPaJ+UlWBc1ZWBWdLg==}
     engines: {node: '>=0.8'}
+    dev: true
+
+  /console-clear/1.1.1:
+    resolution: {integrity: sha512-pMD+MVR538ipqkG5JXeOEbKWS5um1H4LUUccUQG68qpeqBYbzYy79Gh55jkd2TtPdRfUaLWdv6LPP//5Zt0aPQ==}
+    engines: {node: '>=4'}
+    dev: false
+
+  /content-disposition/0.5.2:
+    resolution: {integrity: sha1-DPaLud318r55YcOoUXjLhdunjLQ=}
+    engines: {node: '>= 0.6'}
     dev: true
 
   /content-disposition/0.5.3:
@@ -3172,10 +4044,25 @@ packages:
       nth-check: 1.0.2
     dev: false
 
+  /css-select/4.1.3:
+    resolution: {integrity: sha512-gT3wBNd9Nj49rAbmtFHj1cljIAOLYSX1nZ8CB7TBO3INYckygm5B7LISU/szY//YmdiSLbJvDLOx9VnMVpMBxA==}
+    dependencies:
+      boolbase: 1.0.0
+      css-what: 5.0.1
+      domhandler: 4.2.0
+      domutils: 2.7.0
+      nth-check: 2.0.0
+    dev: true
+
   /css-what/3.4.2:
     resolution: {integrity: sha512-ACUm3L0/jiZTqfzRM3Hi9Q8eZqd6IK37mMWPLz9PJxkLWllYeRf+EHUSHYEtFop2Eqytaq1FizFVh7XfBnXCDQ==}
     engines: {node: '>= 6'}
     dev: false
+
+  /css-what/5.0.1:
+    resolution: {integrity: sha512-FYDTSHb/7KXsWICVsxdmiExPjCfRC4qRFBdVwv7Ax9hMnvMmEjP9RfxTEZ3qPZGmADDn2vAKSo9UcN1jKVYscg==}
+    engines: {node: '>= 6'}
+    dev: true
 
   /css.escape/1.5.1:
     resolution: {integrity: sha1-QuJ9T6BK4y+TGktNQZH6nN3ul8s=}
@@ -3208,6 +4095,10 @@ packages:
     dependencies:
       cssom: 0.3.8
     dev: true
+
+  /csstype/3.0.8:
+    resolution: {integrity: sha512-jXKhWqXPmlUeoQnF/EhTtTl4C9SnrxSH/jZUih3jmO6lBKr99rP3/+FmrMj4EFpOXzMtXHAZkd3x0E6h6Fgflw==}
+    dev: false
 
   /csv-generate/3.3.0:
     resolution: {integrity: sha512-EXSru4QwEWKwM7wwsJbhrZC+mHEJrhQFoXlohHs80CAU8Qhlv9gaw1sjzNiC3Hr3oUx5skDmEiAlz+tnKWV0RA==}
@@ -3414,7 +4305,6 @@ packages:
   /diff-sequences/26.6.2:
     resolution: {integrity: sha512-Mv/TDa3nZ9sbc5soK+OoA74BsS3mL37yixCvUAQkiuA4Wz6YtwP/K47n2rv2ovzHZvoiQeA5FTQOschKkEwB0Q==}
     engines: {node: '>= 10.14.2'}
-    dev: true
 
   /diff/3.5.0:
     resolution: {integrity: sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==}
@@ -3476,7 +4366,6 @@ packages:
     resolution: {integrity: sha512-gd3ypIPfOMr9h5jIKq8E3sHOTCjeirnl0WK5ZdS1AW0Odt0b1PaWaHdJ4Qk4klv+YB9aJBS7mESXjFoDQPu6DA==}
     dependencies:
       utila: 0.4.0
-    dev: false
 
   /dom-serializer/0.2.2:
     resolution: {integrity: sha512-2/xPb3ORsQ42nHYiSunXkDjPLBaEj/xTwUO4B7XCZQTRk7EBtTOPaygh10YAAh2OI1Qrp6NWfpAhzswj0ydt9g==}
@@ -3485,6 +4374,14 @@ packages:
       entities: 2.2.0
     dev: false
 
+  /dom-serializer/1.3.2:
+    resolution: {integrity: sha512-5c54Bk5Dw4qAxNOI1pFEizPSjVsx5+bpJKmL2kPn8JhBUq2q09tTCa3mjijun2NfK78NMouDYNMBkOrPZiS+ig==}
+    dependencies:
+      domelementtype: 2.2.0
+      domhandler: 4.2.0
+      entities: 2.2.0
+    dev: true
+
   /domelementtype/1.3.1:
     resolution: {integrity: sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w==}
     dev: false
@@ -3492,6 +4389,10 @@ packages:
   /domelementtype/2.1.0:
     resolution: {integrity: sha512-LsTgx/L5VpD+Q8lmsXSHW2WpA+eBlZ9HPf3erD1IoPF00/3JKHZ3BknUVA2QGDNu69ZNmyFmCWBSO45XjYKC5w==}
     dev: false
+
+  /domelementtype/2.2.0:
+    resolution: {integrity: sha512-DtBMo82pv1dFtUmHyr48beiuq792Sxohr+8Hm9zoxklYPfa6n0Z3Byjj2IV7bmr2IyqClnqEQhfgHJJ5QF0R5A==}
+    dev: true
 
   /domexception/2.0.1:
     resolution: {integrity: sha512-yxJ2mFy/sibVQlu5qHjOkf9J3K6zgmCxgJ94u2EdvDOV09H+32LtRswEcUsmUWN72pVLOEnTSRaIVVzVQgS0dg==}
@@ -3506,6 +4407,13 @@ packages:
       domelementtype: 1.3.1
     dev: false
 
+  /domhandler/4.2.0:
+    resolution: {integrity: sha512-zk7sgt970kzPks2Bf+dwT/PLzghLnsivb9CcxkvR8Mzr66Olr0Ofd8neSbglHJHaHa2MadfoSdNlKYAaafmWfA==}
+    engines: {node: '>= 4'}
+    dependencies:
+      domelementtype: 2.2.0
+    dev: true
+
   /domutils/1.7.0:
     resolution: {integrity: sha512-Lgd2XcJ/NjEw+7tFvfKxOzCYKZsdct5lczQ2ZaQY8Djz7pfAD3Gbp8ySJWtreII/vDlMVmxwa6pHmdxIYgttDg==}
     dependencies:
@@ -3513,12 +4421,19 @@ packages:
       domelementtype: 1.3.1
     dev: false
 
+  /domutils/2.7.0:
+    resolution: {integrity: sha512-8eaHa17IwJUPAiB+SoTYBo5mCdeMgdcAoXJ59m6DT1vw+5iLS3gNoqYaRowaBKtGVrOF1Jz4yDTgYKLK2kvfJg==}
+    dependencies:
+      dom-serializer: 1.3.2
+      domelementtype: 2.2.0
+      domhandler: 4.2.0
+    dev: true
+
   /dot-case/3.0.4:
     resolution: {integrity: sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==}
     dependencies:
       no-case: 3.0.4
       tslib: 2.1.0
-    dev: false
 
   /dotenv/8.2.0:
     resolution: {integrity: sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw==}
@@ -3625,7 +4540,6 @@ packages:
 
   /entities/2.2.0:
     resolution: {integrity: sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==}
-    dev: false
 
   /envinfo/7.7.4:
     resolution: {integrity: sha512-TQXTYFVVwwluWSFis6K2XKxgrD22jEv0FTuLCQI+OjH7rn93+iY0fSSFM5lrSxFY+H1+B0/cvvlamr3UsBivdQ==}
@@ -3731,6 +4645,20 @@ packages:
       - eslint
     dev: true
 
+  /eslint-config-ts-important-stuff/1.1.0:
+    resolution: {integrity: sha512-WNQO3CqXETekc4lRmdKn+uPpHsCuj/o9mTDFtHkEbLiwVZo2b3fiuWncdbm4hKnTUlACMJGYAirQVIMXnBHblw==}
+    dependencies:
+      eslint-config-important-stuff: 1.1.0
+    dev: true
+
+  /eslint-config-ts-react-important-stuff/3.0.0_eslint@7.20.0:
+    resolution: {integrity: sha512-MX5mgE+GGO/QL14GzA0IDPC9aDyMCMS3GllCwTl6FmtmC7jRXxXn33oJux6RwTlt3Z9mcxHlSnjqC6uDBrQKxA==}
+    dependencies:
+      eslint-config-react-important-stuff: 3.0.0_eslint@7.20.0
+    transitivePeerDependencies:
+      - eslint
+    dev: true
+
   /eslint-plugin-jsx-a11y/6.4.1_eslint@7.20.0:
     resolution: {integrity: sha512-0rGPJBbwHoGNPU73/QCLP/vveMlM1b1Z9PponxO87jfr6tuH5ligXbDT6nHSSzBC8ovX2Z+BQu7Bk5D/Xgq9zg==}
     engines: {node: '>=4.0'}
@@ -3797,8 +4725,8 @@ packages:
     engines: {node: '>=4'}
     dev: true
 
-  /eslint-visitor-keys/2.0.0:
-    resolution: {integrity: sha512-QudtT6av5WXels9WjIM7qz1XD1cWGvX4gGXvp/zBn9nXG02D0utdU3Em2m/QjTnrsk6bBjmCygl3rmj118msQQ==}
+  /eslint-visitor-keys/2.1.0:
+    resolution: {integrity: sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==}
     engines: {node: '>=10'}
     dev: true
 
@@ -3817,7 +4745,7 @@ packages:
       enquirer: 2.3.6
       eslint-scope: 5.1.1
       eslint-utils: 2.1.0
-      eslint-visitor-keys: 2.0.0
+      eslint-visitor-keys: 2.1.0
       espree: 7.3.1
       esquery: 1.4.0
       esutils: 2.0.3
@@ -3832,7 +4760,7 @@ packages:
       js-yaml: 3.14.1
       json-stable-stringify-without-jsonify: 1.0.1
       levn: 0.4.1
-      lodash: 4.17.20
+      lodash: 4.17.21
       minimatch: 3.0.4
       natural-compare: 1.4.0
       optionator: 0.9.1
@@ -3887,6 +4815,18 @@ packages:
     engines: {node: '>=4.0'}
     dev: true
 
+  /estree-walker/0.6.1:
+    resolution: {integrity: sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w==}
+    dev: true
+
+  /estree-walker/1.0.1:
+    resolution: {integrity: sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==}
+    dev: true
+
+  /estree-walker/2.0.2:
+    resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
+    dev: true
+
   /esutils/2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
@@ -3919,6 +4859,19 @@ packages:
 
   /execa/0.7.0:
     resolution: {integrity: sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=}
+    engines: {node: '>=4'}
+    dependencies:
+      cross-spawn: 5.1.0
+      get-stream: 3.0.0
+      is-stream: 1.1.0
+      npm-run-path: 2.0.2
+      p-finally: 1.0.0
+      signal-exit: 3.0.3
+      strip-eof: 1.0.0
+    dev: true
+
+  /execa/0.8.0:
+    resolution: {integrity: sha1-2NdrvBtVIX7RkP1t1J08d07PyNo=}
     engines: {node: '>=4'}
     dependencies:
       cross-spawn: 5.1.0
@@ -4084,6 +5037,10 @@ packages:
     engines: {'0': node >=0.6.0}
     dev: true
 
+  /fast-deep-equal/2.0.1:
+    resolution: {integrity: sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=}
+    dev: true
+
   /fast-deep-equal/3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
@@ -4119,6 +5076,12 @@ packages:
 
   /fast-levenshtein/2.0.6:
     resolution: {integrity: sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=}
+    dev: true
+
+  /fast-url-parser/1.1.3:
+    resolution: {integrity: sha1-9K8+qfNNiicc9YrSs3WfQx8LMY0=}
+    dependencies:
+      punycode: 1.3.2
     dev: true
 
   /fastest-levenshtein/1.0.12:
@@ -4389,6 +5352,11 @@ packages:
     engines: {node: '>=8.0.0'}
     dev: true
 
+  /get-port/3.2.0:
+    resolution: {integrity: sha1-3Xzn3hh8Bsi/NTeWrHHgmfCYDrw=}
+    engines: {node: '>=4'}
+    dev: false
+
   /get-stream/3.0.0:
     resolution: {integrity: sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=}
     engines: {node: '>=4'}
@@ -4635,7 +5603,6 @@ packages:
   /he/1.2.0:
     resolution: {integrity: sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==}
     hasBin: true
-    dev: false
 
   /hosted-git-info/2.8.8:
     resolution: {integrity: sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg==}
@@ -4676,7 +5643,6 @@ packages:
       param-case: 3.0.4
       relateurl: 0.2.7
       terser: 4.8.0
-    dev: false
 
   /html-webpack-plugin/5.1.0_webpack@5.22.0:
     resolution: {integrity: sha512-2axkp+2NHmvHUWrKe1dY4LyM3WatQEdFChr42OY7R/Ad7f0AQzaKscGCcqN/FtQBxo8rdfJP7M3RMFDttqok3g==}
@@ -4693,6 +5659,20 @@ packages:
       webpack: 5.22.0
     dev: false
 
+  /html-webpack-plugin/5.3.2_webpack@5.22.0:
+    resolution: {integrity: sha512-HvB33boVNCz2lTyBsSiMffsJ+m0YLIQ+pskblXgN9fnjS1BgEcuAfdInfXfGrkdXV406k9FiDi86eVCDBgJOyQ==}
+    engines: {node: '>=10.13.0'}
+    peerDependencies:
+      webpack: ^5.20.0
+    dependencies:
+      '@types/html-minifier-terser': 5.1.1
+      html-minifier-terser: 5.1.1
+      lodash: 4.17.21
+      pretty-error: 3.0.4
+      tapable: 2.2.0
+      webpack: 5.22.0_webpack-cli@4.5.0
+    dev: true
+
   /htmlparser2/3.10.1:
     resolution: {integrity: sha512-IgieNijUMbkDovyoKObU1DUhm1iwNYE/fuifEoEHfd1oZKZDaONBSkal7Y01shxsM49R4XaMdGez3WnF9UfiCQ==}
     dependencies:
@@ -4703,6 +5683,15 @@ packages:
       inherits: 2.0.4
       readable-stream: 3.6.0
     dev: false
+
+  /htmlparser2/6.1.0:
+    resolution: {integrity: sha512-gyyPk6rgonLFEDGoeRgQNaEUvdJ4ktTmmUh/h2t7s+M8oPpIPxgNACWa+6ESR57kXstwqPiCut0V8NRpcwgU7A==}
+    dependencies:
+      domelementtype: 2.2.0
+      domhandler: 4.2.0
+      domutils: 2.7.0
+      entities: 2.2.0
+    dev: true
 
   /http-deceiver/1.2.7:
     resolution: {integrity: sha1-+nFolEq5pRnTN8sL7HKE3D5yPYc=}
@@ -4888,6 +5877,10 @@ packages:
 
   /inherits/2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+
+  /ini/1.3.8:
+    resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
+    dev: true
 
   /inquirer/7.3.3:
     resolution: {integrity: sha512-JG3eIAj5V9CwcGvuOmoo6LB9kbAYT8HXffUl6memuszlwDC/qvFAJw49XJ5NROSFNPxp3iQg1GqkFhaY/CR0IA==}
@@ -5087,6 +6080,10 @@ packages:
       ip-regex: 4.3.0
     dev: true
 
+  /is-module/1.0.0:
+    resolution: {integrity: sha1-Mlj7afeMFNW4FdZkM2tM/7ZEFZE=}
+    dev: true
+
   /is-negative-zero/2.0.1:
     resolution: {integrity: sha512-2z6JzQvZRa9A2Y7xC6dQQm4FSTSTNWjKIYYTt4246eMTJmIo0Q+ZyOsU66X8lxK1AbB92dFeglPLrhwpeRKO6w==}
     engines: {node: '>= 0.4'}
@@ -5128,6 +6125,12 @@ packages:
   /is-redirect/1.0.0:
     resolution: {integrity: sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ=}
     engines: {node: '>=0.10.0'}
+
+  /is-reference/1.2.1:
+    resolution: {integrity: sha512-U82MsXXiFIrjCK4otLT+o2NA2Cd2g5MLoOVXUZjIOhLurrRxpEXzI8O0KZHr3IjLvlAH1kTPYSuqer5T9ZVBKQ==}
+    dependencies:
+      '@types/estree': 0.0.46
+    dev: true
 
   /is-regex/1.1.2:
     resolution: {integrity: sha512-axvdhb5pdhEVThqJzYXwMlVuZwC+FF2DpcOhTS+y/8jVq4trxyPgfcwIxIKiyeuLlSQYKkmUaPQJ8ZE4yNKXDg==}
@@ -5368,7 +6371,6 @@ packages:
       diff-sequences: 26.6.2
       jest-get-type: 26.3.0
       pretty-format: 26.6.2
-    dev: true
 
   /jest-docblock/26.0.0:
     resolution: {integrity: sha512-RDZ4Iz3QbtRWycd8bUEPxQsTlYazfYn/h5R65Fc6gOfwozFhoImx+affzky/FFBuqISPTqjXomoIGJVKBWoo0w==}
@@ -5420,7 +6422,6 @@ packages:
   /jest-get-type/26.3.0:
     resolution: {integrity: sha512-TpfaviN1R2pQWkIihlfEanwOXK0zcxrKEE4MlU6Tn7keoXdN6/3gK/xl0yEh8DOunn5pOVGKf8hB4R9gVh04ig==}
     engines: {node: '>= 10.14.2'}
-    dev: true
 
   /jest-haste-map/26.6.2:
     resolution: {integrity: sha512-easWIJXIw71B2RdR8kgqpjQrbMRWQBgiBwXYEhtGUTaX+doCjBheluShdDMeR8IMfJiTqH4+zfhtg29apJf/8w==}
@@ -5894,7 +6895,6 @@ packages:
   /kleur/3.0.3:
     resolution: {integrity: sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==}
     engines: {node: '>=6'}
-    dev: true
 
   /language-subtag-registry/0.3.21:
     resolution: {integrity: sha512-L0IqwlIXjilBVVYKFT37X9Ih11Um5NEl9cbJIuU/SwP/zEEAbBPOnEeeuxVMf45ydWQRDQN3Nqc96OgbH1K+Pg==}
@@ -5936,6 +6936,24 @@ packages:
   /lines-and-columns/1.1.6:
     resolution: {integrity: sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=}
 
+  /livereload-js/3.3.2:
+    resolution: {integrity: sha512-w677WnINxFkuixAoUEXOStewzLYGI76XVag+0JWMMEyjJQKs0ibWZMxkTlB96Lm3EjZ7IeOxVziBEbtxVQqQZA==}
+    dev: true
+
+  /livereload/0.9.3:
+    resolution: {integrity: sha512-q7Z71n3i4X0R9xthAryBdNGVGAO2R5X+/xXpmKeuPMrteg+W2U8VusTKV3YiJbXZwKsOlFlHe+go6uSNjfxrZw==}
+    engines: {node: '>=8.0.0'}
+    hasBin: true
+    dependencies:
+      chokidar: 3.5.1
+      livereload-js: 3.3.2
+      opts: 2.0.2
+      ws: 7.4.3
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+    dev: true
+
   /load-yaml-file/0.2.0:
     resolution: {integrity: sha512-OfCBkGEw4nN6JLtgRidPX6QxjBQGQf72q3si2uvqyFEMbycSFFHwAZeXx6cJgFM9wmLrf9zBwCP3Ivqa+LLZPw==}
     engines: {node: '>=6'}
@@ -5966,6 +6984,11 @@ packages:
       big.js: 5.2.2
       emojis-list: 3.0.0
       json5: 2.2.0
+
+  /local-access/1.1.0:
+    resolution: {integrity: sha512-XfegD5pyTAfb+GY6chk283Ox5z8WexG56OvM06RWLpAc/UHozO8X6xAxEkIitZOtsSMM1Yr3DkHgW5W+onLhCw==}
+    engines: {node: '>=6'}
+    dev: false
 
   /locate-path/3.0.0:
     resolution: {integrity: sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==}
@@ -6002,6 +7025,10 @@ packages:
   /lodash/4.17.20:
     resolution: {integrity: sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==}
 
+  /lodash/4.17.21:
+    resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
+    dev: true
+
   /log-symbols/2.2.0:
     resolution: {integrity: sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==}
     engines: {node: '>=4'}
@@ -6019,7 +7046,6 @@ packages:
     resolution: {integrity: sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==}
     dependencies:
       tslib: 2.1.0
-    dev: false
 
   /lowercase-keys/1.0.1:
     resolution: {integrity: sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==}
@@ -6041,6 +7067,12 @@ packages:
   /lz-string/1.4.4:
     resolution: {integrity: sha1-wNjq82BZ9wV5bh40SBHPTEmNOiY=}
     hasBin: true
+    dev: true
+
+  /magic-string/0.25.7:
+    resolution: {integrity: sha512-4CrMT5DOHTDk4HYDlzmwu4FVCcIYI8gauveasrdCu2IKIFOJ3f0v/8MDGJCDL9oD2ppz/Av1b0Nj345H9M+XIA==}
+    dependencies:
+      sourcemap-codec: 1.4.8
     dev: true
 
   /make-dir/3.1.0:
@@ -6198,6 +7230,11 @@ packages:
       picomatch: 2.2.2
     dev: true
 
+  /mime-db/1.33.0:
+    resolution: {integrity: sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ==}
+    engines: {node: '>= 0.6'}
+    dev: true
+
   /mime-db/1.45.0:
     resolution: {integrity: sha512-CkqLUxUk15hofLoLyljJSrukZi8mAtgd+yE5uO4tqRZsdsAJKv0O+rFMhVDRJgozy+yG6md5KwuXhD4ocIoP+w==}
     engines: {node: '>= 0.6'}
@@ -6206,6 +7243,13 @@ packages:
   /mime-db/1.46.0:
     resolution: {integrity: sha512-svXaP8UQRZ5K7or+ZmfNhg2xX3yKDMUzqadsSqi4NCH/KomcH75MAMYAGVlvXn4+b/xOPhS3I2uHKRUzvjY7BQ==}
     engines: {node: '>= 0.6'}
+    dev: true
+
+  /mime-types/2.1.18:
+    resolution: {integrity: sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==}
+    engines: {node: '>= 0.6'}
+    dependencies:
+      mime-db: 1.33.0
     dev: true
 
   /mime-types/2.1.28:
@@ -6291,7 +7335,6 @@ packages:
   /mri/1.1.6:
     resolution: {integrity: sha512-oi1b3MfbyGa7FJMP9GmLTttni5JoICpYBRlq+x5V16fZbLsnL9N3wFqqIm/nIG43FjUFkFh9Epzp/kzUGUnJxQ==}
     engines: {node: '>=4'}
-    dev: true
 
   /ms/2.0.0:
     resolution: {integrity: sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=}
@@ -6391,7 +7434,6 @@ packages:
     dependencies:
       lower-case: 2.0.2
       tslib: 2.1.0
-    dev: false
 
   /node-fetch/2.6.1:
     resolution: {integrity: sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==}
@@ -6477,6 +7519,12 @@ packages:
     dependencies:
       boolbase: 1.0.0
     dev: false
+
+  /nth-check/2.0.0:
+    resolution: {integrity: sha512-i4sc/Kj8htBrAiH1viZ0TgU8Y5XqCaV/FziYK6TBczxmeKm3AEFWqqF3195yKudrarqy7Zu80Ra5dobFjn9X/Q==}
+    dependencies:
+      boolbase: 1.0.0
+    dev: true
 
   /nwsapi/2.2.0:
     resolution: {integrity: sha512-h2AatdwYH+JHiZpv7pt/gSX1XoRGb7L/qSIeuqA6GwYoF9w1vP1cw42TO0aI2pNyshRK5893hNSl+1//vHK7hQ==}
@@ -6613,6 +7661,10 @@ packages:
       word-wrap: 1.2.3
     dev: true
 
+  /opts/2.0.2:
+    resolution: {integrity: sha512-k41FwbcLnlgnFh69f4qdUfvDQ+5vaSDnVPFI/y5XuhKRq97EnVVneO9F1ESVCdiVu4fCS2L8usX3mU331hB7pg==}
+    dev: true
+
   /original/1.0.2:
     resolution: {integrity: sha512-hyBVl6iqqUOJ8FqRe+l/gS8H+kKYjrEndd5Pm1MfBtsEKA038HkkdbAl/72EAXGyonD/PFsvmVG+EvcIpliMBg==}
     dependencies:
@@ -6731,7 +7783,6 @@ packages:
     dependencies:
       dot-case: 3.0.4
       tslib: 2.1.0
-    dev: false
 
   /parent-module/1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
@@ -6760,6 +7811,10 @@ packages:
     resolution: {integrity: sha512-ugq4DFI0Ptb+WWjAdOK16+u/nHfiIrcE+sh8kZMaM0WllQKLI9rOUq6c2b7cwPkXdzfQESqvoqK6ug7U/Yyzug==}
     dev: true
 
+  /parse5/6.0.1:
+    resolution: {integrity: sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==}
+    dev: false
+
   /parseurl/1.3.3:
     resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
     engines: {node: '>= 0.8'}
@@ -6770,7 +7825,6 @@ packages:
     dependencies:
       no-case: 3.0.4
       tslib: 2.1.0
-    dev: false
 
   /pascalcase/0.1.1:
     resolution: {integrity: sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=}
@@ -6791,6 +7845,10 @@ packages:
     resolution: {integrity: sha1-F0uSaHNVNP+8es5r9TpanhtcX18=}
     engines: {node: '>=0.10.0'}
 
+  /path-is-inside/1.0.2:
+    resolution: {integrity: sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=}
+    dev: true
+
   /path-key/2.0.1:
     resolution: {integrity: sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=}
     engines: {node: '>=4'}
@@ -6810,6 +7868,10 @@ packages:
     resolution: {integrity: sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==}
     dependencies:
       isarray: 0.0.1
+    dev: true
+
+  /path-to-regexp/2.2.1:
+    resolution: {integrity: sha512-gu9bD6Ta5bwGrrU8muHzVOBFFREpp2iRkVfhBJahwJ6p6Xw20SjT0MxLnwkjOibQmGSYhiUnf2FLe7k+jcFmGQ==}
     dev: true
 
   /path-type/3.0.0:
@@ -6969,6 +8031,16 @@ packages:
       fast-diff: 1.2.0
     dev: true
 
+  /prettier-plugin-svelte/1.4.2_prettier@2.2.1+svelte@3.38.3:
+    resolution: {integrity: sha512-O9VsNwII+raTG8QPoQWouk5ABQy/hmLm4dZ2eqJ7DPnbO35A+BxMSjlfqkw0cNP+UcbykHFYU8zNXm93ytWP9g==}
+    peerDependencies:
+      prettier: ^1.16.4 || ^2.0.0
+      svelte: ^3.2.0
+    dependencies:
+      prettier: 2.2.1
+      svelte: 3.38.3
+    dev: true
+
   /prettier/1.19.1:
     resolution: {integrity: sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==}
     engines: {node: '>=4'}
@@ -6992,6 +8064,13 @@ packages:
       renderkid: 2.0.5
     dev: false
 
+  /pretty-error/3.0.4:
+    resolution: {integrity: sha512-ytLFLfv1So4AO1UkoBF6GXQgJRaKbiSiGFICaOPNwQ3CMvBvXpLRubeQWyPGnsbV/t9ml9qto6IeCsho0aEvwQ==}
+    dependencies:
+      lodash: 4.17.21
+      renderkid: 2.0.7
+    dev: true
+
   /pretty-format/26.6.2:
     resolution: {integrity: sha512-7AeGuCYNGmycyQbCqd/3PWH4eOoX/OiCa0uphp57NVTeAGdJGaAliecxwBDHYQCIvrW7aDBZCYeNTP/WX69mkg==}
     engines: {node: '>= 10'}
@@ -7000,7 +8079,6 @@ packages:
       ansi-regex: 5.0.0
       ansi-styles: 4.3.0
       react-is: 17.0.1
-    dev: true
 
   /pretty-quick/3.1.0_prettier@2.2.1:
     resolution: {integrity: sha512-DtxIxksaUWCgPFN7E1ZZk4+Aav3CCuRdhrDSFZENb404sYMtuo9Zka823F+Mgeyt8Zt3bUiCjFzzWYE9LYqkmQ==}
@@ -7098,6 +8176,11 @@ packages:
       safe-buffer: 5.2.1
     dev: true
 
+  /range-parser/1.2.0:
+    resolution: {integrity: sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4=}
+    engines: {node: '>= 0.6'}
+    dev: true
+
   /range-parser/1.2.1:
     resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
     engines: {node: '>= 0.6'}
@@ -7113,6 +8196,16 @@ packages:
       unpipe: 1.0.0
     dev: true
 
+  /rc/1.2.8:
+    resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
+    hasBin: true
+    dependencies:
+      deep-extend: 0.6.0
+      ini: 1.3.8
+      minimist: 1.2.5
+      strip-json-comments: 2.0.1
+    dev: true
+
   /react-dom/17.0.1_react@17.0.1:
     resolution: {integrity: sha512-6eV150oJZ9U2t9svnsspTMrWNyHc6chX0KzDeAOXftRa8bNeOKTTfCJ7KorIwenkHd2xqVTBTCZd79yk/lx/Ug==}
     peerDependencies:
@@ -7126,7 +8219,6 @@ packages:
 
   /react-is/17.0.1:
     resolution: {integrity: sha512-NAnt2iGDXohE5LI7uBnLnqvLQMtzhkiAOLXTmv+qnF9Ky7xAPcX8Up/xWIhxvLVGJvuLiNc4xQLtuqDRzb4fSA==}
-    dev: true
 
   /react/17.0.1:
     resolution: {integrity: sha512-lG9c9UuMHdcAexXtigOZLX8exLWkW0Ku29qPRU8uhF2R9BN96dLCt0psvzPLlHc5OWkgymP3qwTRgbnw5BKx3w==}
@@ -7290,6 +8382,20 @@ packages:
       unicode-match-property-value-ecmascript: 1.2.0
     dev: true
 
+  /registry-auth-token/3.3.2:
+    resolution: {integrity: sha512-JL39c60XlzCVgNrO+qq68FoNb56w/m7JYvGR2jT5iR1xBrUA3Mfx5Twk5rqTThPmQKMWydGmq8oFtDlxfrmxnQ==}
+    dependencies:
+      rc: 1.2.8
+      safe-buffer: 5.2.1
+    dev: true
+
+  /registry-url/3.1.0:
+    resolution: {integrity: sha1-PU74cPc93h138M+aOBQyRE4XSUI=}
+    engines: {node: '>=0.10.0'}
+    dependencies:
+      rc: 1.2.8
+    dev: true
+
   /regjsgen/0.5.2:
     resolution: {integrity: sha512-OFFT3MfrH90xIW8OOSyUrk6QHD5E9JOTeGodiJeBS3J6IwlgzJMNE/1bZklWz5oTg+9dCMyEetclvCVXOPoN3A==}
     dev: true
@@ -7304,7 +8410,6 @@ packages:
   /relateurl/0.2.7:
     resolution: {integrity: sha1-VNvzd+UUQKypCkzSdGANP/LYiKk=}
     engines: {node: '>= 0.10'}
-    dev: false
 
   /remove-trailing-separator/1.1.0:
     resolution: {integrity: sha1-wkvOKig62tW8P1jg1IJJuSN52O8=}
@@ -7318,6 +8423,16 @@ packages:
       lodash: 4.17.20
       strip-ansi: 3.0.1
     dev: false
+
+  /renderkid/2.0.7:
+    resolution: {integrity: sha512-oCcFyxaMrKsKcTY59qnCAtmDVSLfPbrv6A3tVbPdFMMrv5jaK10V6m40cKsoPNhAqN6rmHW9sswW4o3ruSrwUQ==}
+    dependencies:
+      css-select: 4.1.3
+      dom-converter: 0.2.0
+      htmlparser2: 6.1.0
+      lodash: 4.17.21
+      strip-ansi: 3.0.1
+    dev: true
 
   /repeat-element/1.1.3:
     resolution: {integrity: sha512-ahGq0ZnV5m5XtZLMb+vP76kcAM5nkLqk0lpqAuojSKGgQtn4eRi4ZZGm2olo2zKFH+sMsWaqOCW1dqAnOru72g==}
@@ -7393,6 +8508,10 @@ packages:
   /require-main-filename/2.0.0:
     resolution: {integrity: sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==}
 
+  /require-relative/0.8.7:
+    resolution: {integrity: sha1-eZlTn8ngR6N5KPoZb44VY9q9Nt4=}
+    dev: true
+
   /requires-port/1.0.0:
     resolution: {integrity: sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=}
     dev: true
@@ -7456,6 +8575,55 @@ packages:
     dependencies:
       glob: 7.1.6
 
+  /rollup-plugin-livereload/2.0.0:
+    resolution: {integrity: sha512-oC/8NqumGYuphkqrfszOHUUIwzKsaHBICw6QRwT5uD07gvePTS+HW+GFwu6f9K8W02CUuTvtIM9AWJrbj4wE1A==}
+    engines: {node: '>=8.3'}
+    dependencies:
+      livereload: 0.9.3
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+    dev: true
+
+  /rollup-plugin-svelte/7.1.0_rollup@2.52.3+svelte@3.38.3:
+    resolution: {integrity: sha512-vopCUq3G+25sKjwF5VilIbiY6KCuMNHP1PFvx2Vr3REBNMDllKHFZN2B9jwwC+MqNc3UPKkjXnceLPEjTjXGXg==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      rollup: '>=2.0.0'
+      svelte: '>=3.5.0'
+    dependencies:
+      require-relative: 0.8.7
+      rollup: 2.52.3
+      rollup-pluginutils: 2.8.2
+      svelte: 3.38.3
+    dev: true
+
+  /rollup-plugin-terser/7.0.2_rollup@2.52.3:
+    resolution: {integrity: sha512-w3iIaU4OxcF52UUXiZNsNeuXIMDvFrr+ZXK6bFZ0Q60qyVfq4uLptoS4bbq3paG3x216eQllFZX7zt6TIImguQ==}
+    peerDependencies:
+      rollup: ^2.0.0
+    dependencies:
+      '@babel/code-frame': 7.14.5
+      jest-worker: 26.6.2
+      rollup: 2.52.3
+      serialize-javascript: 4.0.0
+      terser: 5.6.0
+    dev: true
+
+  /rollup-pluginutils/2.8.2:
+    resolution: {integrity: sha512-EEp9NhnUkwY8aif6bxgovPHMoMoNr2FulJziTndpt5H9RdwC47GSGuII9XxpSdzVGM0GWrNPHV6ie1LTNJPaLQ==}
+    dependencies:
+      estree-walker: 0.6.1
+    dev: true
+
+  /rollup/2.52.3:
+    resolution: {integrity: sha512-QF3Sju8Kl2z0osI4unyOLyUudyhOMK6G0AeqJWgfiyigqLAlnNrfBcDWDx+f1cqn+JU2iIYVkDrgQ6/KtwEfrg==}
+    engines: {node: '>=10.0.0'}
+    hasBin: true
+    optionalDependencies:
+      fsevents: 2.3.2
+    dev: true
+
   /rsvp/4.8.5:
     resolution: {integrity: sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==}
     engines: {node: 6.* || >= 7.*}
@@ -7476,6 +8644,13 @@ packages:
     engines: {npm: '>=2.0.0'}
     dependencies:
       tslib: 1.14.1
+
+  /sade/1.7.4:
+    resolution: {integrity: sha512-y5yauMD93rX840MwUJr7C1ysLFBgMspsdTo4UVrDg3fXDvtwOyIqykhVAAm6fk/3au77773itJStObgK+LKaiA==}
+    engines: {node: '>= 6'}
+    dependencies:
+      mri: 1.1.6
+    dev: false
 
   /safe-buffer/5.1.2:
     resolution: {integrity: sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==}
@@ -7560,6 +8735,11 @@ packages:
       node-forge: 0.10.0
     dev: true
 
+  /semiver/1.1.0:
+    resolution: {integrity: sha512-QNI2ChmuioGC1/xjyYwyZYADILWyW6AmS1UH6gDj/SFUUUS4MBAWs/7mxnkRPc/F4iHezDP+O8t0dO8WHiEOdg==}
+    engines: {node: '>=6'}
+    dev: false
+
   /semver-compare/1.0.0:
     resolution: {integrity: sha1-De4hahyUGrN+nvsXiPavxf9VN/w=}
     dev: true
@@ -7608,10 +8788,29 @@ packages:
       statuses: 1.5.0
     dev: true
 
+  /serialize-javascript/4.0.0:
+    resolution: {integrity: sha512-GaNA54380uFefWghODBWEGisLZFj00nS5ACs6yHa9nLqlLpVLO8ChDGeKRjZnV4Nh4n0Qi7nhYZD/9fCPzEqkw==}
+    dependencies:
+      randombytes: 2.1.0
+    dev: true
+
   /serialize-javascript/5.0.1:
     resolution: {integrity: sha512-SaaNal9imEO737H2c05Og0/8LUXG7EnsZyMa8MzkmuHoELfT6txuj0cMqRj6zfPKnmQ1yasR4PCJc8x+M4JSPA==}
     dependencies:
       randombytes: 2.1.0
+    dev: true
+
+  /serve-handler/6.1.3:
+    resolution: {integrity: sha512-FosMqFBNrLyeiIDvP1zgO6YoTzFYHxLDEIavhlmQ+knB2Z7l1t+kGLHkZIDN7UVWqQAmKI3D20A6F6jo3nDd4w==}
+    dependencies:
+      bytes: 3.0.0
+      content-disposition: 0.5.2
+      fast-url-parser: 1.1.3
+      mime-types: 2.1.18
+      minimatch: 3.0.4
+      path-is-inside: 1.0.2
+      path-to-regexp: 2.2.1
+      range-parser: 1.2.0
     dev: true
 
   /serve-index/1.9.1:
@@ -7635,6 +8834,21 @@ packages:
       escape-html: 1.0.3
       parseurl: 1.3.3
       send: 0.17.1
+    dev: true
+
+  /serve/11.3.2:
+    resolution: {integrity: sha512-yKWQfI3xbj/f7X1lTBg91fXBP0FqjJ4TEi+ilES5yzH0iKJpN5LjNb1YzIfQg9Rqn4ECUS2SOf2+Kmepogoa5w==}
+    hasBin: true
+    dependencies:
+      '@zeit/schemas': 2.6.0
+      ajv: 6.5.3
+      arg: 2.0.0
+      boxen: 1.3.0
+      chalk: 2.4.1
+      clipboardy: 1.2.3
+      compression: 1.7.3
+      serve-handler: 6.1.3
+      update-check: 1.5.2
     dev: true
 
   /set-blocking/2.0.0:
@@ -7710,6 +8924,28 @@ packages:
   /signal-exit/3.0.3:
     resolution: {integrity: sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==}
 
+  /single-spa-layout/1.5.4:
+    resolution: {integrity: sha512-Zx6h3UnDQQyP05unnWtTZi6rsoud3hLqtIKYNkaqbEx3oSZ9yRBMehqdNE0CcW04o1Iiimicf+lmAGYQ21CGEg==}
+    engines: {node: '>=12'}
+    dependencies:
+      '@types/parse5': 5.0.3
+      merge2: 1.4.1
+      parse5: 6.0.1
+      single-spa: 5.9.3
+    dev: false
+
+  /single-spa-react/4.1.0_a3626766904e54ff7fb600102f5c3051:
+    resolution: {integrity: sha512-FLcdXuRrnAuWE6ZwIyE1Bj4uSBaQbOH+WG2nKrvq2p+R/3pSmwNKXotvtojINnnbuaNOGUeYjEKeavRWQc84dQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: '*'
+    dependencies:
+      '@types/react': 16.14.8
+      '@types/react-dom': 16.9.13
+      react: 17.0.1
+    dev: false
+
   /single-spa-react/4.1.0_react@17.0.1:
     resolution: {integrity: sha512-FLcdXuRrnAuWE6ZwIyE1Bj4uSBaQbOH+WG2nKrvq2p+R/3pSmwNKXotvtojINnnbuaNOGUeYjEKeavRWQc84dQ==}
     peerDependencies:
@@ -7718,7 +8954,14 @@ packages:
       react: '*'
     dependencies:
       react: 17.0.1
-    dev: true
+
+  /single-spa-svelte/2.1.1:
+    resolution: {integrity: sha512-ppN9PNk7HNerEYa8fimZkSCYcfSoJL9s/86AHdSB6RsmyWXb7UIdHl4jh989idNVrFvbtE+PyhFGEygQfe+RgA==}
+    dev: false
+
+  /single-spa/5.9.3:
+    resolution: {integrity: sha512-qMGraRzIBsodV6569Fob4cQ4/yQNrcZ5Achh3SAQDljmqUtjAZ7BAA7GAyO/l5eizb7GtTmVq9Di7ORyKw82CQ==}
+    dev: false
 
   /sinon/9.2.4:
     resolution: {integrity: sha512-zljcULZQsJxVra28qIAL6ow1Z9tpattkCTEJR4RBP3TGc00FcttsP5pK284Nas5WjMZU5Yzy3kAIp3B3KRf5Yg==}
@@ -7731,11 +8974,35 @@ packages:
       supports-color: 7.2.0
     dev: true
 
+  /sirv-cli/1.0.12:
+    resolution: {integrity: sha512-Rs5PvF3a48zuLmrl8vcqVv9xF/WWPES19QawVkpdzqx7vD5SMZS07+ece1gK4umbslXN43YeIksYtQM5csgIzQ==}
+    engines: {node: '>= 10'}
+    hasBin: true
+    dependencies:
+      console-clear: 1.1.1
+      get-port: 3.2.0
+      kleur: 3.0.3
+      local-access: 1.1.0
+      sade: 1.7.4
+      semiver: 1.1.0
+      sirv: 1.0.12
+      tinydate: 1.3.0
+    dev: false
+
   /sirv/1.0.11:
     resolution: {integrity: sha512-SR36i3/LSWja7AJNRBz4fF/Xjpn7lQFI30tZ434dIy+bitLYSP+ZEenHg36i23V2SGEz+kqjksg0uOGZ5LPiqg==}
     engines: {node: '>= 10'}
     dependencies:
       '@polka/url': 1.0.0-next.11
+      mime: 2.5.0
+      totalist: 1.1.0
+    dev: false
+
+  /sirv/1.0.12:
+    resolution: {integrity: sha512-+jQoCxndz7L2tqQL4ZyzfDhky0W/4ZJip3XoOuxyQWnAwMxindLl3Xv1qT4x1YX/re0leShvTm8Uk0kQspGhBg==}
+    engines: {node: '>= 10'}
+    dependencies:
+      '@polka/url': 1.0.0-next.15
       mime: 2.5.0
       totalist: 1.1.0
     dev: false
@@ -7864,6 +9131,10 @@ packages:
   /source-map/0.7.3:
     resolution: {integrity: sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==}
     engines: {node: '>= 8'}
+    dev: true
+
+  /sourcemap-codec/1.4.8:
+    resolution: {integrity: sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==}
     dev: true
 
   /spawn-command/0.0.2-1:
@@ -8051,7 +9322,6 @@ packages:
     engines: {node: '>=0.10.0'}
     dependencies:
       ansi-regex: 2.1.1
-    dev: false
 
   /strip-ansi/4.0.0:
     resolution: {integrity: sha1-qEeQIusaw2iocTibY1JixQXuNo8=}
@@ -8117,6 +9387,11 @@ packages:
       min-indent: 1.0.1
     dev: true
 
+  /strip-json-comments/2.0.1:
+    resolution: {integrity: sha1-PFMZQukIwml8DsNEhYwobHygpgo=}
+    engines: {node: '>=0.10.0'}
+    dev: true
+
   /strip-json-comments/3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
@@ -8159,6 +9434,22 @@ packages:
       supports-color: 7.2.0
     dev: true
 
+  /svelte-jester/1.7.0_jest@26.6.3+svelte@3.38.3:
+    resolution: {integrity: sha512-eWJSmxGXR/jetU+gpuAvrSEZT7PpNxrhV2GoUm/WQUtXFjGJcy6sZTq3kKaUz7q8VddHU1/yt9cxDRxo8IUsLA==}
+    engines: {node: '>= 14'}
+    peerDependencies:
+      jest: <= 26
+      svelte: '>= 3'
+    dependencies:
+      jest: 26.6.3
+      svelte: 3.38.3
+    dev: true
+
+  /svelte/3.38.3:
+    resolution: {integrity: sha512-N7bBZJH0iF24wsalFZF+fVYMUOigaAUQMIcEKHO3jstK/iL8VmP9xE+P0/a76+FkNcWt+TDv2Gx1taUoUscrvw==}
+    engines: {node: '>= 8'}
+    dev: true
+
   /symbol-tree/3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
     dev: true
@@ -8176,7 +9467,7 @@ packages:
     engines: {node: '>=10.0.0'}
     dependencies:
       ajv: 7.1.0
-      lodash: 4.17.20
+      lodash: 4.17.21
       slice-ansi: 4.0.0
       string-width: 4.2.0
     dev: true
@@ -8233,7 +9524,6 @@ packages:
       commander: 2.20.3
       source-map: 0.6.1
       source-map-support: 0.5.19
-    dev: false
 
   /terser/5.6.0:
     resolution: {integrity: sha512-vyqLMoqadC1uR0vywqOZzriDYzgEkNJFK4q9GeyOBHIbiECHiWLKcWfbQWAUaPfxkjDhapSlZB9f7fkMrvkVjA==}
@@ -8281,6 +9571,11 @@ packages:
   /timed-out/4.0.1:
     resolution: {integrity: sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8=}
     engines: {node: '>=0.10.0'}
+
+  /tinydate/1.3.0:
+    resolution: {integrity: sha512-7cR8rLy2QhYHpsBDBVYnnWXm8uRTr38RoZakFSW7Bs7PzfMPNZthuMLkwqZv7MTu8lhQ91cOFYS5a7iFj2oR3w==}
+    engines: {node: '>=4'}
+    dev: false
 
   /tmp/0.0.33:
     resolution: {integrity: sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==}
@@ -8374,7 +9669,6 @@ packages:
 
   /tslib/2.1.0:
     resolution: {integrity: sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==}
-    dev: false
 
   /tty-table/2.8.13:
     resolution: {integrity: sha512-eVV/+kB6fIIdx+iUImhXrO22gl7f6VmmYh0Zbu6C196fe1elcHXd7U6LcLXu0YoVPc2kNesWiukYcdK8ZmJ6aQ==}
@@ -8454,7 +9748,6 @@ packages:
     resolution: {integrity: sha512-6OSu9PTIzmn9TCDiovULTnET6BgXtDYL4Gg4szY+cGsc3JP1dQL8qvE8kShTRx1NIw4Q9IBHlwODjkjWEtMUyA==}
     engines: {node: '>=4.2.0'}
     hasBin: true
-    dev: false
 
   /unicode-canonical-property-names-ecmascript/1.0.4:
     resolution: {integrity: sha512-jDrNnXWHd4oHiTZnx/ZG7gtUTVp+gCcTTKr8L0HjlwphROEW3+Him+IpvC+xcJEFegapiMZyZe02CyuOnRmbnQ==}
@@ -8531,6 +9824,13 @@ packages:
     resolution: {integrity: sha1-0vD3N9FrBhXnKmk17QQhRXLVb5c=}
     engines: {node: '>=4'}
 
+  /update-check/1.5.2:
+    resolution: {integrity: sha512-1TrmYLuLj/5ZovwUS7fFd1jMH3NnFDN1y1A8dboedIDt7zs/zJMo6TwwlhYKkSeEwzleeiSBV5/3c9ufAQWDaQ==}
+    dependencies:
+      registry-auth-token: 3.3.2
+      registry-url: 3.1.0
+    dev: true
+
   /uri-js/4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
     dependencies:
@@ -8590,7 +9890,6 @@ packages:
 
   /utila/0.4.0:
     resolution: {integrity: sha1-ihagXURWV6Oupe7MWxKk+lN5dyw=}
-    dev: false
 
   /utils-merge/1.0.1:
     resolution: {integrity: sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=}

--- a/tests/create-fixtures.js
+++ b/tests/create-fixtures.js
@@ -1,0 +1,112 @@
+const { createFixtureIfDoesntExist, ensureInstall } = require("./test-helpers");
+
+module.exports = async () => {
+  await createFixtureIfDoesntExist(
+    "root-config-ts-webpack",
+    `
+      --moduleType root-config
+      --packageManager pnpm
+      --orgName org
+      --typescript
+      --layout=false
+      --skipInstall
+    `
+  );
+
+  await createFixtureIfDoesntExist(
+    "root-config-ts-webpack-layout",
+    `
+      --moduleType root-config
+      --packageManager pnpm
+      --orgName org
+      --typescript
+      --layout=true
+      --skipInstall
+    `
+  );
+
+  await createFixtureIfDoesntExist(
+    "react-app-js-webpack",
+    `
+      --framework react
+      --packageManager pnpm
+      --orgName org
+      --projectName project
+      --typescript=false
+      --skipInstall
+    `
+  );
+
+  await createFixtureIfDoesntExist(
+    "react-app-ts-webpack",
+    `
+      --framework react
+      --packageManager pnpm
+      --orgName org
+      --projectName project
+      --typescript
+      --skipInstall
+    `
+  );
+
+  await createFixtureIfDoesntExist(
+    "root-config-js-webpack-layout",
+    `
+      --moduleType root-config
+      --packageManager pnpm
+      --orgName org
+      --typescript=false
+      --layout=true
+      --skipInstall
+    `
+  );
+
+  await createFixtureIfDoesntExist(
+    "root-config-js-webpack",
+    `
+      --moduleType root-config
+      --packageManager pnpm
+      --orgName org
+      --typescript=false
+      --layout=false
+      --skipInstall
+    `
+  );
+
+  await createFixtureIfDoesntExist(
+    "svelte-app-js",
+    `
+      --framework svelte
+      --packageManager pnpm
+      --orgName org
+      --projectName project
+      --skipInstall
+    `
+  );
+
+  await createFixtureIfDoesntExist(
+    "util-module-js-webpack",
+    `
+      --moduleType util-module
+      --packageManager pnpm
+      --orgName org
+      --projectName project
+      --typescript=false
+      --skipInstall
+    `
+  );
+
+  await createFixtureIfDoesntExist(
+    "util-module-ts-webpack",
+    `
+    --moduleType util-module
+    --packageManager pnpm
+    --orgName org
+    --projectName project
+    --typescript
+    --skipInstall
+  `
+  );
+
+  await ensureInstall();
+};

--- a/tests/e2e/react-app-js-webpack.test.js
+++ b/tests/e2e/react-app-js-webpack.test.js
@@ -1,18 +1,9 @@
-const { createFixtureIfDoesntExist } = require("../test-helpers.js");
+const { getFixtureDir } = require("../test-helpers.js");
 const nixt = require("nixt");
 
-describe(`basic react usage`, () => {
-  const fixtureDir = createFixtureIfDoesntExist(
-    __filename,
-    `
-    --framework react
-    --packageManager pnpm
-    --orgName org
-    --projectName project
-    --typescript=false
-  `
-  );
+const fixtureDir = getFixtureDir(__filename);
 
+describe(`basic react usage`, () => {
   it(`Can pnpm run build`, (done) => {
     console.log("pnpm run build");
     nixt()

--- a/tests/e2e/react-app-ts-webpack.test.js
+++ b/tests/e2e/react-app-ts-webpack.test.js
@@ -1,18 +1,9 @@
-const { createFixtureIfDoesntExist } = require("../test-helpers.js");
+const { getFixtureDir } = require("../test-helpers.js");
 const nixt = require("nixt");
 
-describe(`typescript react usage`, () => {
-  const fixtureDir = createFixtureIfDoesntExist(
-    __filename,
-    `
-    --framework react
-    --packageManager pnpm
-    --orgName org
-    --projectName project
-    --typescript
-  `
-  );
+const fixtureDir = getFixtureDir(__filename);
 
+describe(`typescript react usage`, () => {
   it(`Can pnpm run build`, (done) => {
     console.log("pnpm run build");
     nixt()

--- a/tests/e2e/root-config-js-webpack-layout.test.js
+++ b/tests/e2e/root-config-js-webpack-layout.test.js
@@ -1,18 +1,9 @@
-const { createFixtureIfDoesntExist } = require("../test-helpers.js");
 const nixt = require("nixt");
+const { getFixtureDir } = require("../test-helpers");
+
+const fixtureDir = getFixtureDir(__filename);
 
 describe(`js root config with layout usage`, () => {
-  const fixtureDir = createFixtureIfDoesntExist(
-    __filename,
-    `
-    --moduleType root-config
-    --packageManager pnpm
-    --orgName org
-    --typescript=false
-    --layout=true
-  `
-  );
-
   it(`Can pnpm run build`, (done) => {
     console.log("pnpm run build");
     nixt()

--- a/tests/e2e/root-config-js-webpack.test.js
+++ b/tests/e2e/root-config-js-webpack.test.js
@@ -1,18 +1,9 @@
-const { createFixtureIfDoesntExist } = require("../test-helpers.js");
 const nixt = require("nixt");
+const { getFixtureDir } = require("../test-helpers");
+
+const fixtureDir = getFixtureDir(__filename);
 
 describe(`js root config usage`, () => {
-  const fixtureDir = createFixtureIfDoesntExist(
-    __filename,
-    `
-    --moduleType root-config
-    --packageManager pnpm
-    --orgName org
-    --typescript=false
-    --layout=false
-  `
-  );
-
   it(`Can pnpm run build`, (done) => {
     console.log("pnpm run build");
     nixt()

--- a/tests/e2e/root-config-ts-webpack-layout.test.js
+++ b/tests/e2e/root-config-ts-webpack-layout.test.js
@@ -1,18 +1,9 @@
-const { createFixtureIfDoesntExist } = require("../test-helpers.js");
 const nixt = require("nixt");
+const { getFixtureDir } = require("../test-helpers");
+
+let fixtureDir = getFixtureDir(__filename);
 
 describe(`typescript root config with layout usage`, () => {
-  const fixtureDir = createFixtureIfDoesntExist(
-    __filename,
-    `
-    --moduleType root-config
-    --packageManager pnpm
-    --orgName org
-    --typescript
-    --layout=true
-  `
-  );
-
   it(`Can pnpm run build`, (done) => {
     console.log("pnpm run build");
     nixt()

--- a/tests/e2e/root-config-ts-webpack.test.js
+++ b/tests/e2e/root-config-ts-webpack.test.js
@@ -1,18 +1,9 @@
-const { createFixtureIfDoesntExist } = require("../test-helpers.js");
 const nixt = require("nixt");
+const { getFixtureDir } = require("../test-helpers");
+
+let fixtureDir = getFixtureDir(__filename);
 
 describe(`typescript root config usage`, () => {
-  const fixtureDir = createFixtureIfDoesntExist(
-    __filename,
-    `
-    --moduleType root-config
-    --packageManager pnpm
-    --orgName org
-    --typescript
-    --layout=false
-  `
-  );
-
   it(`Can pnpm run build`, (done) => {
     console.log("pnpm run build");
     nixt()

--- a/tests/e2e/svelte-app-js.test.js
+++ b/tests/e2e/svelte-app-js.test.js
@@ -1,19 +1,9 @@
-const { createFixtureIfDoesntExist } = require("../test-helpers.js");
 const nixt = require("nixt");
+const { getFixtureDir } = require("../test-helpers");
+
+const fixtureDir = getFixtureDir(__filename);
 
 describe(`basic svelte usage`, () => {
-  const fixtureDir = createFixtureIfDoesntExist(
-    __filename,
-    `
-    --framework svelte
-    --packageManager pnpm
-    --orgName org
-    --projectName project
-  `
-  );
-
-  console.log("fixtureDir", fixtureDir);
-
   it(`Can pnpm run build`, (done) => {
     console.log("pnpm run build");
     nixt()

--- a/tests/e2e/util-module-js-webpack.test.js
+++ b/tests/e2e/util-module-js-webpack.test.js
@@ -1,18 +1,9 @@
-const { createFixtureIfDoesntExist } = require("../test-helpers.js");
 const nixt = require("nixt");
+const { getFixtureDir } = require("../test-helpers");
+
+const fixtureDir = getFixtureDir(__filename);
 
 describe(`js util module usage`, () => {
-  const fixtureDir = createFixtureIfDoesntExist(
-    __filename,
-    `
-    --moduleType util-module
-    --packageManager pnpm
-    --orgName org
-    --projectName project
-    --typescript=false
-  `
-  );
-
   it(`Can pnpm run build`, (done) => {
     console.log("pnpm run build");
     nixt()

--- a/tests/e2e/util-module-ts-webpack.test.js
+++ b/tests/e2e/util-module-ts-webpack.test.js
@@ -1,18 +1,9 @@
-const { createFixtureIfDoesntExist } = require("../test-helpers.js");
 const nixt = require("nixt");
+const { getFixtureDir } = require("../test-helpers");
+
+const fixtureDir = getFixtureDir(__filename);
 
 describe(`typescript util module usage`, () => {
-  const fixtureDir = createFixtureIfDoesntExist(
-    __filename,
-    `
-    --moduleType util-module
-    --packageManager pnpm
-    --orgName org
-    --projectName project
-    --typescript
-  `
-  );
-
   it(`Can pnpm run build`, (done) => {
     console.log("pnpm run build");
     nixt()

--- a/tests/test-helpers.js
+++ b/tests/test-helpers.js
@@ -2,19 +2,16 @@ const nixt = require("nixt");
 const fs = require("fs");
 const path = require("path");
 const mkdirp = require("mkdirp");
+const { resolve } = require("path");
 
-exports.createFixtureIfDoesntExist = function (fileName, args) {
-  const name = fileName
-    .replace(__dirname + path.sep + "e2e" + path.sep, "")
-    .replace(".test.js", "");
-
-  const dir = path.join(__dirname, `./fixtures/${name}`);
+exports.createFixtureIfDoesntExist = function (name, args) {
+  const dir = testDir(name);
 
   if (!fs.existsSync(path.join(__dirname, `./fixtures/${name}/package.json`))) {
     const cwd = path.join(__dirname, "./fixtures");
     mkdirp.sync(cwd);
 
-    it(`can successfully generate the '${name}' fixture`, (done) => {
+    return new Promise((resolve, reject) => {
       const argsStr = args.replace(/\s+/g, " ");
 
       console.log(`Creating '${name}' fixture. This could take a while...`);
@@ -29,7 +26,7 @@ exports.createFixtureIfDoesntExist = function (fileName, args) {
         .code(0)
         .end((err) => {
           if (err) {
-            fail(err);
+            reject(err);
           } else {
             const packageJsonPath = path.join(dir, "package.json");
             const packageJson = JSON.parse(
@@ -42,15 +39,44 @@ exports.createFixtureIfDoesntExist = function (fileName, args) {
               "utf-8"
             );
 
-            // pnpm install seems to exit slightly before the node_modules are actually ready to use.
-            // Because of this, we have to guess how long to wait before we try to use them.
-            setTimeout(done, 500);
+            resolve(dir);
           }
         });
     });
   } else {
     console.log(`Reusing existing fixture for ${name}`);
+    resolve(dir);
   }
+};
 
-  return dir;
+exports.ensureInstall = () => {
+  return new Promise((resolve, reject) => {
+    console.log("Running pnpm install for all fixtures");
+    nixt()
+      .cwd(process.cwd())
+      .run("pnpm install")
+      .code(0)
+      .end((err) => {
+        if (err) {
+          reject(err);
+        } else {
+          console.log("pnpm install finished");
+          resolve();
+        }
+      });
+  });
+};
+
+function testName(fileName) {
+  return fileName
+    .replace(__dirname + path.sep + "e2e" + path.sep, "")
+    .replace(".test.js", "");
+}
+
+function testDir(name) {
+  return path.join(__dirname, `./fixtures/${name}`);
+}
+
+exports.getFixtureDir = (fileName) => {
+  return testDir(testName(fileName));
 };


### PR DESCRIPTION
The tests have been flaky for a long time due to pnpm install race conditions. This forces all fixture creation to be done upfront without installing the dependencies, then running pnpm install one time (rather than for each test), then running the jest tests. I am hopeful this will fix the flakiness once and for all. Also, it seems to have made the tests faster. The downside is that I couldn't find a way to only create the selected fixtures for the tests rather than all fixtures, and then still have install run at the end. But I think avoiding the flakiness is worth it.