### PR TITLE
Add angular cli version support

### DIFF
--- a/packages/generator-single-spa/src/angular/validate-cli-version.js
+++ b/packages/generator-single-spa/src/angular/validate-cli-version.js
@@ -1,0 +1,11 @@
+const ALLOWED_CHARACTERS = /^[a-zA-Z0-9\-]+$/;
+
+module.exports = function validateCLIVersion(input) {
+  if (!input) {
+    return `Cannot be empty!`;
+  } else if (!ALLOWED_CHARACTERS.test(input)) {
+    return `May only contain letters, numbers, dash or underscore`;
+  } else {
+    return true;
+  }
+};


### PR DESCRIPTION
It would've been great to use specific angular-cli version in case global is not available or rest of the packages or ecosystem is not ready to handle latest version.

see [angular 13 issue](https://github.com/single-spa/single-spa-angular/issues/395)

