### PR TITLE
fix upgrade-dependencies script

### DIFF
--- a/scripts/upgrade-dependencies.sh
+++ b/scripts/upgrade-dependencies.sh
@@ -1,21 +1,21 @@
 #!/bin/sh
-pnpx ncu -iu --packageFile ./package.json
-pnpx ncu -iu --packageFile ./packages/create-single-spa/package.json
-pnpx ncu -iu --packageFile ./packages/single-spa-web-server-utils/package.json
-pnpx ncu -iu --packageFile ./packages/single-spa-welcome/package.json
-pnpx ncu -iu --packageFile ./packages/ts-config-single-spa/package.json
-pnpx ncu -iu --packageFile ./packages/webpack-config-single-spa/package.json
-pnpx ncu -iu --packageFile ./packages/webpack-config-single-spa-react/package.json
-pnpx ncu -iu --packageFile ./packages/webpack-config-single-spa-react-ts/package.json
-pnpx ncu -iu --packageFile ./packages/webpack-config-single-spa-ts/package.json
+pnpx npm-check-updates -iu --packageFile ./package.json
+pnpx npm-check-updates -iu --packageFile ./packages/create-single-spa/package.json
+pnpx npm-check-updates -iu --packageFile ./packages/single-spa-web-server-utils/package.json
+pnpx npm-check-updates -iu --packageFile ./packages/single-spa-welcome/package.json
+pnpx npm-check-updates -iu --packageFile ./packages/ts-config-single-spa/package.json
+pnpx npm-check-updates -iu --packageFile ./packages/webpack-config-single-spa/package.json
+pnpx npm-check-updates -iu --packageFile ./packages/webpack-config-single-spa-react/package.json
+pnpx npm-check-updates -iu --packageFile ./packages/webpack-config-single-spa-react-ts/package.json
+pnpx npm-check-updates -iu --packageFile ./packages/webpack-config-single-spa-ts/package.json
 
 # generator-single-spa has a bunch of nested package jsons
-pnpx ncu -iu --packageFile ./packages/generator-single-spa/package.json
-pnpx ncu -iu --packageFile ./packages/generator-single-spa/src/common-templates/typescript/react.package.json
-pnpx ncu -iu --packageFile ./packages/generator-single-spa/src/common-templates/typescript/typescript.package.json
-pnpx ncu -iu --packageFile ./packages/generator-single-spa/src/react/templates/react.package.json
-pnpx ncu -iu --packageFile ./packages/generator-single-spa/src/react/templates/typescript/typescript-react.package.json
-pnpx ncu -iu --packageFile ./packages/generator-single-spa/src/root-config/templates/root-config.package.json
-pnpx ncu -iu --packageFile ./packages/generator-single-spa/src/root-config/templates/root-config-layout.package.json
-pnpx ncu -iu --packageFile ./packages/generator-single-spa/src/svelte/templates/svelte.package.json
-pnpx ncu -iu --packageFile ./packages/generator-single-spa/src/util-module/templates/util-module.package.json
+pnpx npm-check-updates -iu --packageFile ./packages/generator-single-spa/package.json
+pnpx npm-check-updates -iu --packageFile ./packages/generator-single-spa/src/common-templates/typescript/react.package.json
+pnpx npm-check-updates -iu --packageFile ./packages/generator-single-spa/src/common-templates/typescript/typescript.package.json
+pnpx npm-check-updates -iu --packageFile ./packages/generator-single-spa/src/react/templates/react.package.json
+pnpx npm-check-updates -iu --packageFile ./packages/generator-single-spa/src/react/templates/typescript/typescript-react.package.json
+pnpx npm-check-updates -iu --packageFile ./packages/generator-single-spa/src/root-config/templates/root-config.package.json
+pnpx npm-check-updates -iu --packageFile ./packages/generator-single-spa/src/root-config/templates/root-config-layout.package.json
+pnpx npm-check-updates -iu --packageFile ./packages/generator-single-spa/src/svelte/templates/svelte.package.json
+pnpx npm-check-updates -iu --packageFile ./packages/generator-single-spa/src/util-module/templates/util-module.package.json


### PR DESCRIPTION
This PR changes the name `ncu` to `npm-check-updates`. While `ncu` is the name of the binary exported by `npm-check-updates`, `ncu` is actually [another package](https://www.npmjs.com/package/ncu).

After this fix, i was able to run the script locally without having `npm-check-updates` installed globally.