### PR TITLE
fix: use @typescript-eslint/parser when react typescript

### DIFF
--- a/.changeset/calm-colts-sell.md
+++ b/.changeset/calm-colts-sell.md
@@ -1,0 +1,5 @@
+---
+"generator-single-spa": patch
+---
+
+fix generator util typescript project use @typescript-eslint/parser as eslint parser

--- a/.changeset/flat-buttons-wonder.md
+++ b/.changeset/flat-buttons-wonder.md
@@ -1,0 +1,5 @@
+---
+"generator-single-spa": patch
+---
+
+fix generator typescript root-config project use @typescript-eslint/parser as eslint parser

--- a/.changeset/ten-monkeys-chew.md
+++ b/.changeset/ten-monkeys-chew.md
@@ -1,0 +1,5 @@
+---
+"generator-single-spa": patch
+---
+
+fix generator react typescript application / parcel project use @typescript-eslint/parser as eslint parser

--- a/packages/generator-single-spa/src/react/generator-single-spa-react.js
+++ b/packages/generator-single-spa/src/react/generator-single-spa-react.js
@@ -86,8 +86,13 @@ module.exports = class SingleSpaReactGenerator extends PnpmGenerator {
       delete packageJson.devDependencies["webpack-config-single-spa"];
       // Will be replaced by webpack-config-single-spa-react-ts
       delete packageJson.devDependencies["webpack-config-single-spa-ts"];
+      // Will be replaced by @typescript-eslint/parser
+      delete packageJson.devDependencies["@babel/eslint-parser"];
 
       packageJson.types = `dist/${this.options.orgName}-${this.options.projectName}.d.ts`;
+    } else {
+      // Will be replaced by @babel/eslint-parser
+      delete packageJson.devDependencies["@typescript-eslint/parser"];
     }
 
     this.fs.extendJSON(this.destinationPath("package.json"), packageJson);

--- a/packages/generator-single-spa/src/react/templates/.eslintrc.ejs
+++ b/packages/generator-single-spa/src/react/templates/.eslintrc.ejs
@@ -3,5 +3,5 @@
     <%if (typescript) { %>"ts-react-important-stuff",<%} else { %>"react-important-stuff",<% } %>
     "plugin:prettier/recommended"
   ],
-  "parser": "@babel/eslint-parser"
+  "parser": <%if (typescript) { %>"@typescript-eslint/parser"<%} else { %>"@babel/eslint-parser"<% } %>
 }

--- a/packages/generator-single-spa/src/react/templates/react.package.json
+++ b/packages/generator-single-spa/src/react/templates/react.package.json
@@ -23,6 +23,7 @@
     "@babel/runtime": "^7.15.3",
     "@testing-library/jest-dom": "^5.14.1",
     "@testing-library/react": "^12.0.0",
+    "@typescript-eslint/parser": "^5.13.0",
     "babel-jest": "^27.0.6",
     "concurrently": "^6.2.1",
     "cross-env": "^7.0.3",

--- a/packages/generator-single-spa/src/root-config/generator-root-config.js
+++ b/packages/generator-single-spa/src/root-config/generator-root-config.js
@@ -84,7 +84,13 @@ module.exports = class SingleSpaRootConfigGenerator extends PnpmGenerator {
       delete packageJson.devDependencies["eslint-config-important-stuff"];
       // Will be replaced by webpack-config-single-spa-ts
       delete packageJson.devDependencies["webpack-config-single-spa"];
+      // Will be replaced by @typescript-eslint/parser
+      delete packageJson.devDependencies["@babel/eslint-parser"];
+
       packageJson.types = `dist/${this.options.orgName}-root-config.d.ts`;
+    } else {
+      // Will be replaced by @babel/eslint-parser
+      delete packageJson.devDependencies["@typescript-eslint/parser"];
     }
 
     this.fs.extendJSON(this.destinationPath("package.json"), packageJson);

--- a/packages/generator-single-spa/src/root-config/templates/.eslintrc.ejs
+++ b/packages/generator-single-spa/src/root-config/templates/.eslintrc.ejs
@@ -1,4 +1,4 @@
 {
   "extends": ["<% if (typescript) { %>ts-<% } %>important-stuff", "plugin:prettier/recommended"],
-  "parser": "@babel/eslint-parser"
+  "parser": <%if (typescript) { %>"@typescript-eslint/parser"<%} else { %>"@babel/eslint-parser"<% } %>
 }

--- a/packages/generator-single-spa/src/root-config/templates/root-config.package.json
+++ b/packages/generator-single-spa/src/root-config/templates/root-config.package.json
@@ -16,6 +16,7 @@
     "@babel/plugin-transform-runtime": "^7.15.0",
     "@babel/preset-env": "^7.15.0",
     "@babel/runtime": "^7.15.3",
+    "@typescript-eslint/parser": "^5.13.0",
     "concurrently": "^6.2.1",
     "cross-env": "^7.0.3",
     "eslint": "^7.32.0",

--- a/packages/generator-single-spa/src/util-module/generator-single-spa-util-module.js
+++ b/packages/generator-single-spa/src/util-module/generator-single-spa-util-module.js
@@ -80,8 +80,13 @@ module.exports = class SingleSpaUtilModuleGenerator extends PnpmGenerator {
       delete packageJson.devDependencies["eslint-config-important-stuff"];
       // Will be replaced by webpack-config-single-spa-ts
       delete packageJson.devDependencies["webpack-config-single-spa"];
+      // Will be replaced by @typescript-eslint/parser
+      delete packageJson.devDependencies["@babel/eslint-parser"];
 
       packageJson.types = `dist/${this.options.orgName}-${this.options.projectName}.d.ts`;
+    } else {
+      // Will be replaced by @babel/eslint-parser
+      delete packageJson.devDependencies["@typescript-eslint/parser"];
     }
 
     this.fs.extendJSON(this.destinationPath("package.json"), packageJson);

--- a/packages/generator-single-spa/src/util-module/templates/.eslintrc.ejs
+++ b/packages/generator-single-spa/src/util-module/templates/.eslintrc.ejs
@@ -3,5 +3,5 @@
     <%if (typescript) { %>"ts-important-stuff",<%} else { %>"important-stuff",<% } %>
     "plugin:prettier/recommended"
   ],
-  "parser": "@babel/eslint-parser"
+  "parser": <%if (typescript) { %>"@typescript-eslint/parser"<%} else { %>"@babel/eslint-parser"<% } %>
 }

--- a/packages/generator-single-spa/src/util-module/templates/util-module.package.json
+++ b/packages/generator-single-spa/src/util-module/templates/util-module.package.json
@@ -20,6 +20,7 @@
     "@babel/plugin-transform-runtime": "^7.15.0",
     "@babel/preset-env": "^7.15.0",
     "@babel/runtime": "^7.15.3",
+    "@typescript-eslint/parser": "^5.13.0",
     "babel-jest": "^27.0.6",
     "concurrently": "^6.2.1",
     "cross-env": "^7.0.3",


### PR DESCRIPTION
maybe should I support both @babel/eslint-parser and @typescript-eslint/parser via eslint overrides?
