### PR TITLE
Extract svg into own loader for easier overrides

### DIFF
--- a/.changeset/fast-suns-do.md
+++ b/.changeset/fast-suns-do.md
@@ -1,0 +1,5 @@
+---
+"webpack-config-single-spa": minor
+---
+
+Extract svg into own loader for easier overrides

--- a/packages/webpack-config-single-spa/lib/webpack-config-single-spa.js
+++ b/packages/webpack-config-single-spa/lib/webpack-config-single-spa.js
@@ -88,7 +88,13 @@ function webpackConfigSingleSpa(opts) {
           ],
         },
         {
-          test: /\.(bmp|png|svg|jpg|jpeg|gif|webp)$/i,
+          test: /\.(bmp|png|jpg|jpeg|gif|webp)$/i,
+          exclude: /node_modules/,
+          type: "asset/resource",
+        },
+        // svg has its own loader to allow easier overriding (eg. svg-loader for React components)
+        {
+          test: /\.svg$/i,
           exclude: /node_modules/,
           type: "asset/resource",
         },


### PR DESCRIPTION
I was helping someone in the single-spa Slack who was having issues with conflicting SVG loaders. Our webpack config [includes svgs in the list of images](https://github.com/single-spa/create-single-spa/blob/main/packages/webpack-config-single-spa/lib/webpack-config-single-spa.js#L91) to process as resources, so its difficult to define a different loader for SVGs. SVGs are also very commonly imported as React components so this is a valuable usecase to accommodate. Prior to this change, one would need to filter out the problematic rule and the provide their own. 

```js
const { mergeWithCustomize, customizeArray } = require("webpack-merge");
const singleSpaDefaults = require("webpack-config-single-spa-react-ts");

const mergeCustom = mergeWithCustomize({
  customizeArray: customizeArray({
    "module.rules": "replace"
  })
});

module.exports = (webpackConfigEnv, argv) => {
  const defaultConfig = singleSpaDefaults({
    orgName: "abcde",
    projectName: "fghij",
    webpackConfigEnv,
    argv
  });

  const rules = defaultConfig.module.rules.map((rule) => {
    if (rule.test.toString().includes("svg")) {
      // remove svg from list of file types
      rule.test = /\.(bmp|png|jpg|jpeg|gif|webp)$/i;
    }
    return rule;
  });

  const finalConfig = mergeCustom(defaultConfig, {
    module: {
      rules: [
        ...rules,
        {
          test: /\.svg$/i,
          use: [
            {
              loader: "@svgr/webpack",
              options: {
                typescript: true
              }
            }
          ]
        }
      ]
    }
  });

  return finalConfig;
};

```

After this change, one would only need to define [webpack-merge's `mergeWithRules`](https://github.com/survivejs/webpack-merge#mergewithrules) and use that.

```js
const { mergeWithRules } = require('webpack-merge');
const singleSpaDefaults = require('webpack-config-single-spa-react-ts');

const merge = mergeWithRules({
  module: {
    rules: {
      test: 'match',
      use: 'replace',
    },
  },
});

module.exports = (webpackConfigEnv, argv) => {
  const defaultConfig = singleSpaDefaults({
    orgName: 'abcde',
    projectName: 'fghij',
    webpackConfigEnv,
    argv,
  });

  const finalConfig = merge(defaultConfig, {
    module: {
      rules: [
        {
          test: /\.svg$/i,
          use: [
            {
              loader: '@svgr/webpack',
              options: {
                typescript: true,
              },
            },
          ],
        },
      ],
    },
  });

  return finalConfig
};
```