### PR TITLE
Update single-spa-react to 6.0.1 for welcome app

### DIFF
--- a/.changeset/wild-islands-melt.md
+++ b/.changeset/wild-islands-melt.md
@@ -1,0 +1,5 @@
+---
+"single-spa-welcome": patch
+---
+
+Update version of single-spa-react

--- a/packages/single-spa-welcome/package.json
+++ b/packages/single-spa-welcome/package.json
@@ -51,7 +51,7 @@
     "jest-cli": "^27.5.1",
     "prettier": "^2.3.2",
     "pretty-quick": "^3.1.1",
-    "single-spa-react": "^5.1.4",
+    "single-spa-react": "^6.0.1",
     "style-loader": "^3.2.1",
     "ts-config-single-spa": "workspace:*",
     "webpack": "^5.89.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -186,8 +186,8 @@ importers:
         specifier: ^3.1.1
         version: 3.1.3(prettier@2.8.8)
       single-spa-react:
-        specifier: ^5.1.4
-        version: 5.1.4(react@17.0.2)
+        specifier: ^6.0.1
+        version: 6.0.1(react@17.0.2)
       style-loader:
         specifier: ^3.2.1
         version: 3.3.3(webpack@5.89.0)
@@ -10160,8 +10160,8 @@ packages:
       react: 17.0.2
     dev: false
 
-  /single-spa-react@5.1.4(react@17.0.2):
-    resolution: {integrity: sha512-5hdDJVFaP7dYnst1Y0AkzvfcQ+8wT2Clc/DXJY76AJ55ZdV3fgJYoP5zq2sl57ycjUEeITvuQxV4Uj5XY5IxOQ==}
+  /single-spa-react@6.0.1(react@17.0.2):
+    resolution: {integrity: sha512-kRFQN0uAibFV7QrJCG1pau7pixPgToQA4f/Pcn2Ojfs3ETbmXhaGkViSE1KIH0ZsxUu4JcaE2ArNMn5iK8srqA==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'


### PR DESCRIPTION
Reported on Slack: @single-spa/welcome dies with the message `SKIP_BECAUSE_BROKEN: renderType “createRoot” did not return a function.`. This updates @single-spa/welcome to use single-spa-react@^6.0.1 since the underlying issue appears to be the same as single-spa/single-spa-react#202.

Verified this fix in a local root config.